### PR TITLE
[FEAT] 결제 요청 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // --- Redis ---
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
 }
 
 kotlin {

--- a/src/main/kotlin/com/pgcore/core/application/port/out/CardApprovalGateway.kt
+++ b/src/main/kotlin/com/pgcore/core/application/port/out/CardApprovalGateway.kt
@@ -9,6 +9,10 @@ interface CardApprovalGateway {
     /**
      * 카드 승인 Provider(카드사/카드 서비스)에 승인을 요청합니다.
      * @param providerRequestId 우리 시스템이 생성한 요청 ID (Provider 측 멱등키 역할)
+     * @param merchantId 가맹점 ID
+     * @param orderId 주문 ID
+     * @param billingKey 빌링키
+     * @param amount 요청 금액
      */
     fun approve(
         providerRequestId: String,

--- a/src/main/kotlin/com/pgcore/core/application/port/out/CardApprovalGateway.kt
+++ b/src/main/kotlin/com/pgcore/core/application/port/out/CardApprovalGateway.kt
@@ -1,0 +1,20 @@
+package com.pgcore.core.application.port.out
+
+import com.pgcore.core.application.port.out.dto.CardApprovalResult
+
+/**
+ * 카드 승인 Provider(카드사/카드 서비스) 호출 Port
+ */
+interface CardApprovalGateway {
+    /**
+     * 카드 승인 Provider(카드사/카드 서비스)에 승인을 요청합니다.
+     * @param providerRequestId 우리 시스템이 생성한 요청 ID (Provider 측 멱등키 역할)
+     */
+    fun approve(
+        providerRequestId: String,
+        merchantId: String,
+        orderId: String,
+        billingKey: String,
+        amount: Long
+    ): CardApprovalResult
+}

--- a/src/main/kotlin/com/pgcore/core/application/port/out/dto/CardApprovalResult.kt
+++ b/src/main/kotlin/com/pgcore/core/application/port/out/dto/CardApprovalResult.kt
@@ -4,7 +4,7 @@ package com.pgcore.core.application.port.out.dto
  * 카드 승인 결과(Provider 응답을 우리 시스템이 쓰기 좋은 형태로 정리)
  */
 data class CardApprovalResult(
-    val isSuccess: Boolean,
+    val status: CardApprovalStatus,
     val providerTxId: String?,   // 카드사/Provider 트랜잭션 ID
     val failureCode: String?
 )

--- a/src/main/kotlin/com/pgcore/core/application/port/out/dto/CardApprovalResult.kt
+++ b/src/main/kotlin/com/pgcore/core/application/port/out/dto/CardApprovalResult.kt
@@ -1,0 +1,10 @@
+package com.pgcore.core.application.port.out.dto
+
+/**
+ * 카드 승인 결과(Provider 응답을 우리 시스템이 쓰기 좋은 형태로 정리)
+ */
+data class CardApprovalResult(
+    val isSuccess: Boolean,
+    val providerTxId: String?,   // 카드사/Provider 트랜잭션 ID
+    val failureCode: String?
+)

--- a/src/main/kotlin/com/pgcore/core/application/port/out/dto/CardApprovalResult.kt
+++ b/src/main/kotlin/com/pgcore/core/application/port/out/dto/CardApprovalResult.kt
@@ -1,10 +1,10 @@
 package com.pgcore.core.application.port.out.dto
 
 /**
- * 카드 승인 결과(Provider 응답을 우리 시스템이 쓰기 좋은 형태로 정리)
+ * 카드 승인 결과
  */
 data class CardApprovalResult(
     val status: CardApprovalStatus,
-    val providerTxId: String?,   // 카드사/Provider 트랜잭션 ID
+    val providerTxId: String?,
     val failureCode: String?
 )

--- a/src/main/kotlin/com/pgcore/core/application/port/out/dto/CardApprovalStatus.kt
+++ b/src/main/kotlin/com/pgcore/core/application/port/out/dto/CardApprovalStatus.kt
@@ -1,0 +1,6 @@
+package com.pgcore.core.application.port.out.dto
+
+enum class CardApprovalStatus {
+    SUCCESS,
+    FAIL;
+}

--- a/src/main/kotlin/com/pgcore/core/application/repository/PaymentMutationRepository.kt
+++ b/src/main/kotlin/com/pgcore/core/application/repository/PaymentMutationRepository.kt
@@ -1,0 +1,15 @@
+package com.pgcore.core.application.repository
+
+interface PaymentMutationRepository {
+    // 1. 상태 선점 (READY -> IN_PROGRESS)
+    fun tryMarkInProgress(paymentKey: String, amount: Long): Int
+    
+    // 2. 승인 성공 시 확정 (IN_PROGRESS -> DONE)
+    fun finalizeApproveSuccess(paymentKey: String): Int
+    
+    // 3. 승인 실패 시 취소 (IN_PROGRESS -> ABORTED)
+    fun finalizeApproveFail(paymentKey: String): Int
+    
+    // 4. 통신 타임아웃/장애 시 불명 상태 마킹 (-> UNKNOWN)
+    fun markUnknown(paymentKey: String): Int
+}

--- a/src/main/kotlin/com/pgcore/core/application/repository/PaymentRepository.kt
+++ b/src/main/kotlin/com/pgcore/core/application/repository/PaymentRepository.kt
@@ -5,4 +5,5 @@ import com.pgcore.core.domain.payment.Payment
 interface PaymentRepository {
     fun saveAndFlush(payment: Payment): Payment
     fun findByMerchantIdAndOrderId(merchantId: Long, orderId: String): Payment?
+    fun findByPaymentKey(paymentKey: String): Payment?
 }

--- a/src/main/kotlin/com/pgcore/core/application/repository/PaymentTransactionRepository.kt
+++ b/src/main/kotlin/com/pgcore/core/application/repository/PaymentTransactionRepository.kt
@@ -1,0 +1,9 @@
+package com.pgcore.core.application.repository
+
+import com.pgcore.core.domain.payment.PaymentTransaction
+
+interface PaymentTransactionRepository {
+    fun saveAndFlush(transaction: PaymentTransaction): PaymentTransaction
+    fun save(transaction: PaymentTransaction): PaymentTransaction
+    fun findById(txId: Long): PaymentTransaction?
+}

--- a/src/main/kotlin/com/pgcore/core/application/usecase/command/ClaimPaymentUseCase.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/command/ClaimPaymentUseCase.kt
@@ -3,16 +3,14 @@ package com.pgcore.core.application.usecase.command
 import com.pgcore.core.application.repository.PaymentRepository
 import com.pgcore.core.application.usecase.command.dto.ClaimPaymentCommand
 import com.pgcore.core.application.usecase.command.dto.ClaimPaymentResult
-import com.pgcore.core.domain.enums.PaymentStatus
+import com.pgcore.core.common.PaymentKeyGenerator
 import com.pgcore.core.domain.exception.PaymentErrorCode
 import com.pgcore.core.domain.payment.Payment
 import com.pgcore.core.domain.payment.vo.Money
 import com.pgcore.core.exception.BusinessException
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
-import java.util.UUID
 
 @Service
 class ClaimPaymentUseCase(
@@ -37,7 +35,7 @@ class ClaimPaymentUseCase(
 
         // 2) 신규 생성: TTL 30분 부여
         val payment = Payment.create(
-            paymentKey = generatePaymentKey(),
+            paymentKey = PaymentKeyGenerator.generate(),
             merchantId = command.merchantId,
             orderId = command.orderId,
             orderName = command.orderName,
@@ -79,12 +77,4 @@ class ClaimPaymentUseCase(
         if (existing.totalAmount.amount != command.amount) throw BusinessException(PaymentErrorCode.DUPLICATE_ORDER_ID_AMOUNT_MISMATCH)
         if (existing.orderName.trim() != command.orderName.trim()) throw BusinessException(PaymentErrorCode.DUPLICATE_ORDER_ID_NAME_MISMATCH)
     }
-
-    /**
-     * 결제키 생성
-     * - 현재는 UUID 기반
-     * - 향후 ULID/KSUID 등으로 교체 가능(필요하면 별도 Generator로 분리)
-     */
-    private fun generatePaymentKey(): String =
-        "pay_" + UUID.randomUUID().toString().replace("-", "")
 }

--- a/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmPaymentUseCase.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmPaymentUseCase.kt
@@ -1,0 +1,61 @@
+package com.pgcore.core.application.usecase.command
+
+import com.pgcore.core.application.port.out.CardApprovalGateway
+import com.pgcore.core.application.repository.PaymentRepository
+import com.pgcore.core.application.usecase.command.dto.ConfirmPaymentCommand
+import com.pgcore.core.application.usecase.command.dto.ConfirmPaymentResult
+import com.pgcore.core.domain.exception.PaymentErrorCode
+import com.pgcore.core.domain.payment.vo.Money
+import com.pgcore.core.exception.BusinessException
+import org.springframework.stereotype.Service
+
+@Service
+class ConfirmPaymentUseCase(
+    private val paymentRepository: PaymentRepository,
+    private val cardApprovalGateway: CardApprovalGateway,
+    private val step1Writer: ConfirmStep1Writer,
+    private val step2Writer: ConfirmStep2Writer
+) {
+    fun execute(command: ConfirmPaymentCommand): ConfirmPaymentResult {
+
+        // 1) 원장 검증 및 크로스 체크
+        val payment = paymentRepository.findByPaymentKey(command.paymentKey)
+            ?: throw BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND)
+
+        if (payment.totalAmount != Money(command.amount)) {
+            throw BusinessException(PaymentErrorCode.REQUEST_TOTAL_AMOUNT_MISMATCH)
+        }
+
+        if (payment.orderId != command.orderId) {
+            throw BusinessException(PaymentErrorCode.REQUEST_ORDER_ID_MISMATCH)
+        }
+
+        // 2) Step 1: 상태 선점 (TX-1)
+        val txId = step1Writer.acquireInProgressAndCreateTx(command, payment.paymentId)
+
+        try {
+            // 3) 외부 API 통신 (TX 밖)
+            val providerResponse = cardApprovalGateway.approve(
+                providerRequestId = txId.toString(),
+                merchantId = command.merchantId.toString(),
+                orderId = payment.orderId,
+                billingKey = command.billingKey,
+                amount = command.amount
+            )
+
+            // 4) Step 2: 결과 반영 (TX-2)
+            val transaction = step2Writer.finalizeTransaction(
+                command = command,
+                txId = txId,
+                isSuccess = providerResponse.isSuccess,
+                providerTxId = providerResponse.providerTxId,
+                failureCode = providerResponse.failureCode
+            )
+
+            return ConfirmPaymentResult.from(transaction, command.paymentKey)
+        } catch (e: Exception) {
+            runCatching { step2Writer.markAsUnknown(command, txId) }
+            throw e
+        }
+    }
+}

--- a/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmPaymentUseCase.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmPaymentUseCase.kt
@@ -1,6 +1,7 @@
 package com.pgcore.core.application.usecase.command
 
 import com.pgcore.core.application.port.out.CardApprovalGateway
+import com.pgcore.core.application.port.out.dto.CardApprovalStatus
 import com.pgcore.core.application.repository.PaymentRepository
 import com.pgcore.core.application.usecase.command.dto.ConfirmPaymentCommand
 import com.pgcore.core.application.usecase.command.dto.ConfirmPaymentResult
@@ -32,8 +33,8 @@ class ConfirmPaymentUseCase(
 
         // 2) Step 1: 상태 선점 (TX-1)
         val txId = step1Writer.acquireInProgressAndCreateTx(command, payment.paymentId)
-        var isPgSuccess: Boolean? = null
-        var pgProviderTxId: String? = null
+        var approvalStatus: CardApprovalStatus? = null
+        var providerTxId: String? = null
 
         try {
             // 3) 외부 API 통신 (TX 밖)
@@ -45,16 +46,14 @@ class ConfirmPaymentUseCase(
                 amount = command.amount
             )
 
-            isPgSuccess = providerResponse.isSuccess
-            pgProviderTxId = providerResponse.providerTxId
+            approvalStatus = providerResponse.status
+            providerTxId = providerResponse.providerTxId
 
             // 4) Step 2: 결과 반영 (TX-2)
             val transaction = step2Writer.finalizeTransaction(
                 command = command,
                 txId = txId,
-                isSuccess = providerResponse.isSuccess,
-                providerTxId = providerResponse.providerTxId,
-                failureCode = providerResponse.failureCode
+                approvalResult = providerResponse
             )
 
             return ConfirmPaymentResult.from(transaction, command.paymentKey)
@@ -63,8 +62,8 @@ class ConfirmPaymentUseCase(
                 step2Writer.handleExceptionAndMarkUnknown(
                     command = command,
                     txId = txId,
-                    isPgSuccess = isPgSuccess,
-                    providerTxId = pgProviderTxId
+                    approvalStatus = approvalStatus,
+                    providerTxId = providerTxId,
                 )
             }
             throw e

--- a/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmPaymentUseCase.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmPaymentUseCase.kt
@@ -32,6 +32,8 @@ class ConfirmPaymentUseCase(
 
         // 2) Step 1: 상태 선점 (TX-1)
         val txId = step1Writer.acquireInProgressAndCreateTx(command, payment.paymentId)
+        var isPgSuccess: Boolean? = null
+        var pgProviderTxId: String? = null
 
         try {
             // 3) 외부 API 통신 (TX 밖)
@@ -42,6 +44,9 @@ class ConfirmPaymentUseCase(
                 billingKey = command.billingKey,
                 amount = command.amount
             )
+
+            isPgSuccess = providerResponse.isSuccess
+            pgProviderTxId = providerResponse.providerTxId
 
             // 4) Step 2: 결과 반영 (TX-2)
             val transaction = step2Writer.finalizeTransaction(
@@ -54,7 +59,14 @@ class ConfirmPaymentUseCase(
 
             return ConfirmPaymentResult.from(transaction, command.paymentKey)
         } catch (e: Exception) {
-            runCatching { step2Writer.markAsUnknown(command, txId) }
+            runCatching {
+                step2Writer.handleExceptionAndMarkUnknown(
+                    command = command,
+                    txId = txId,
+                    isPgSuccess = isPgSuccess,
+                    providerTxId = pgProviderTxId
+                )
+            }
             throw e
         }
     }

--- a/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmStep1Writer.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmStep1Writer.kt
@@ -53,28 +53,16 @@ class ConfirmStep1Writer(
         val payment = paymentRepository.findByPaymentKey(command.paymentKey)
             ?: return BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND)
 
-        if (payment.totalAmount != Money(command.amount)) {
-            return BusinessException(
-                PaymentErrorCode.REQUEST_TOTAL_AMOUNT_MISMATCH,
-            )
-        }
+        validateAmount(command, payment.totalAmount)
 
-        return when (payment.status) {
-            // 결제 유효기간 만료 → 새 결제로 재시도 유도
-            PaymentStatus.EXPIRED -> BusinessException(PaymentErrorCode.PAYMENT_EXPIRED)
+        return resolveByStatus(payment.status)
+    }
 
-            // 이미 누군가 선점하고 처리 중
-            PaymentStatus.IN_PROGRESS -> BusinessException(PaymentErrorCode.IDEMPOTENCY_PROCESSING)
-
-            // 이미 최종 완료/실패로 끝난 결제
-            PaymentStatus.DONE, PaymentStatus.ABORTED, PaymentStatus.CANCEL, PaymentStatus.PARTIAL_CANCEL ->
-                BusinessException(PaymentErrorCode.ALREADY_PROCESSED)
-
-            // 확정불가(망취소 대기/UNKNOWN)는 재시도를 막고 조회/대사로 유도하는 게 안전
-            PaymentStatus.UNKNOWN -> BusinessException(PaymentErrorCode.IDEMPOTENCY_RETRY_BLOCKED)
-
-            // READY로 보이지만 CAS가 실패했다면 레이스/읽기 불일치/상태 꼬임 가능성이 있어 안전하게 STATE_LOST로 처리
-            PaymentStatus.READY -> BusinessException(PaymentErrorCode.IDEMPOTENCY_STATE_LOST)
+    private fun validateAmount(command: ConfirmPaymentCommand, totalAmount: Money) {
+        if (totalAmount != Money(command.amount)) {
+            throw BusinessException(PaymentErrorCode.REQUEST_TOTAL_AMOUNT_MISMATCH)
         }
     }
+
+    private fun resolveByStatus(status: PaymentStatus): BusinessException = status.toConfirmException()
 }

--- a/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmStep1Writer.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmStep1Writer.kt
@@ -68,7 +68,7 @@ class ConfirmStep1Writer(
 
             // 이미 최종 완료/실패로 끝난 결제
             PaymentStatus.DONE, PaymentStatus.ABORTED, PaymentStatus.CANCEL, PaymentStatus.PARTIAL_CANCEL ->
-                BusinessException(PaymentErrorCode.PAYMENT_ALREADY_COMPLETED)
+                BusinessException(PaymentErrorCode.ALREADY_PROCESSED)
 
             // 확정불가(망취소 대기/UNKNOWN)는 재시도를 막고 조회/대사로 유도하는 게 안전
             PaymentStatus.UNKNOWN -> BusinessException(PaymentErrorCode.IDEMPOTENCY_RETRY_BLOCKED)

--- a/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmStep1Writer.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmStep1Writer.kt
@@ -1,0 +1,80 @@
+package com.pgcore.core.application.usecase.command
+
+import com.pgcore.core.application.repository.PaymentMutationRepository
+import com.pgcore.core.application.repository.PaymentRepository
+import com.pgcore.core.application.repository.PaymentTransactionRepository
+import com.pgcore.core.application.usecase.command.dto.ConfirmPaymentCommand
+import com.pgcore.core.domain.enums.PaymentStatus
+import com.pgcore.core.domain.exception.PaymentErrorCode
+import com.pgcore.core.domain.payment.PaymentTransaction
+import com.pgcore.core.domain.payment.vo.Money
+import com.pgcore.core.exception.BusinessException
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class ConfirmStep1Writer(
+    private val paymentRepository: PaymentRepository,
+    private val paymentMutationRepository: PaymentMutationRepository,
+    private val paymentTransactionRepository: PaymentTransactionRepository
+) {
+    /**
+     * [Step 1] 결제 상태를 IN_PROGRESS로 선점하고 이력을 PENDING으로 생성합니다.
+     * 외부 통신 전에 트랜잭션을 끝내기 위해 REQUIRES_NEW를 사용합니다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun acquireInProgressAndCreateTx(command: ConfirmPaymentCommand, internalPaymentId: Long): Long {
+
+        // 1. CAS 방식으로 결제 상태 선점 (READY -> IN_PROGRESS)
+        val affectedRows = paymentMutationRepository.tryMarkInProgress(
+            paymentKey = command.paymentKey,
+            amount = command.amount
+        )
+
+        // 2. 업데이트된 데이터가 없다면, 이미 다른 스레드가 처리중이거나 금액 변조
+        if (affectedRows == 0) {
+            throw resolveWhyCasFailed(command)
+        }
+
+        // 3. 결제 이력(Transaction)을 PENDING 상태로 생성
+        val transaction = PaymentTransaction.createApprove(
+            paymentId = internalPaymentId,
+            merchantId = command.merchantId,
+            requestedAmount = Money(command.amount),
+            idempotencyKey = command.idempotencyKey
+        )
+
+        // 4. DB에 즉시 반영하고 생성된 식별자(txId) 반환 (Provider 통신 시 고유 요청 ID로 사용)
+        return paymentTransactionRepository.saveAndFlush(transaction).id
+    }
+
+    private fun resolveWhyCasFailed(command: ConfirmPaymentCommand): BusinessException {
+        val payment = paymentRepository.findByPaymentKey(command.paymentKey)
+            ?: return BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND)
+
+        if (payment.totalAmount != Money(command.amount)) {
+            return BusinessException(
+                PaymentErrorCode.REQUEST_TOTAL_AMOUNT_MISMATCH,
+            )
+        }
+
+        return when (payment.status) {
+            // 결제 유효기간 만료 → 새 결제로 재시도 유도
+            PaymentStatus.EXPIRED -> BusinessException(PaymentErrorCode.PAYMENT_EXPIRED)
+
+            // 이미 누군가 선점하고 처리 중
+            PaymentStatus.IN_PROGRESS -> BusinessException(PaymentErrorCode.IDEMPOTENCY_PROCESSING)
+
+            // 이미 최종 완료/실패로 끝난 결제
+            PaymentStatus.DONE, PaymentStatus.ABORTED, PaymentStatus.CANCEL, PaymentStatus.PARTIAL_CANCEL ->
+                BusinessException(PaymentErrorCode.PAYMENT_ALREADY_COMPLETED)
+
+            // 확정불가(망취소 대기/UNKNOWN)는 재시도를 막고 조회/대사로 유도하는 게 안전
+            PaymentStatus.UNKNOWN -> BusinessException(PaymentErrorCode.IDEMPOTENCY_RETRY_BLOCKED)
+
+            // READY로 보이지만 CAS가 실패했다면 레이스/읽기 불일치/상태 꼬임 가능성이 있어 안전하게 STATE_LOST로 처리
+            PaymentStatus.READY -> BusinessException(PaymentErrorCode.IDEMPOTENCY_STATE_LOST)
+        }
+    }
+}

--- a/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmStep2Writer.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmStep2Writer.kt
@@ -55,8 +55,8 @@ class ConfirmStep2Writer(
             if (affectedRows == 0) {
                 handleStateMismatch(command, transaction, false, providerTxId, failureCode)
             } else {
-                val mappedCode = mapFailureCode(failureCode)
-                val reason = buildFailureReason(mappedCode, failureCode)
+                val mappedCode = PaymentTxFailureCode.fromRawCode(failureCode)
+                val reason = mappedCode.buildReason(failureCode)
 
                 transaction.markFail(mappedCode, reason)
                 paymentTransactionRepository.saveAndFlush(transaction)
@@ -98,9 +98,9 @@ class ConfirmStep2Writer(
                 when (transaction.status) {
                     PaymentTxStatus.FAIL -> transaction
                     else -> {
-                        val mapped = mapFailureCode(failureCode)
-                        val reason = buildFailureReason(mapped, failureCode)
-                        transaction.markFail(mapped, reason)
+                        val mappedCode = PaymentTxFailureCode.fromRawCode(failureCode)
+                        val reason = mappedCode.buildReason(failureCode)
+                        transaction.markFail(mappedCode, reason)
                         paymentTransactionRepository.saveAndFlush(transaction)
                     }
                 }
@@ -120,47 +120,6 @@ class ConfirmStep2Writer(
                 paymentTransactionRepository.saveAndFlush(transaction)
                 throw BusinessException(PaymentErrorCode.INTERNAL_ERROR)
             }
-        }
-    }
-
-    private fun mapFailureCode(rawFailureCode: String?): PaymentTxFailureCode =
-        rawFailureCode
-            ?.takeIf { it.isNotBlank() }
-            ?.let { runCatching { PaymentTxFailureCode.valueOf(it) }.getOrNull() }
-            ?: PaymentTxFailureCode.INTERNAL_ERROR
-
-    private fun buildFailureReason(code: PaymentTxFailureCode, rawFailureCode: String?): String {
-        val raw = rawFailureCode?.let { " (code=$it)" } ?: ""
-        return when (code) {
-            PaymentTxFailureCode.CARD_BLOCKED ->
-                "카드 사용이 정지(분실/도난 신고 또는 이용 제한)되어 승인에 실패했습니다.$raw"
-
-            PaymentTxFailureCode.CARD_EXPIRED ->
-                "카드 유효기간 만료로 승인에 실패했습니다.$raw"
-
-            PaymentTxFailureCode.INSUFFICIENT_FUNDS ->
-                "잔액 부족으로 승인에 실패했습니다.$raw"
-
-            PaymentTxFailureCode.LIMIT_EXCEEDED ->
-                "한도 초과로 승인에 실패했습니다.$raw"
-
-            PaymentTxFailureCode.INVALID_CARD ->
-                "유효하지 않은 카드 정보로 승인에 실패했습니다.$raw"
-
-            PaymentTxFailureCode.INVALID_PIN_OR_CVC ->
-                "비밀번호(PIN) 또는 CVC 오류로 승인에 실패했습니다.$raw"
-
-            PaymentTxFailureCode.FRAUD_SUSPECTED ->
-                "부정 사용 의심으로 카드사에서 승인을 거절했습니다.$raw"
-
-            PaymentTxFailureCode.MERCHANT_NOT_ALLOWED ->
-                "해당 가맹점에서는 사용이 허용되지 않아 승인에 실패했습니다.$raw"
-
-            PaymentTxFailureCode.DUPLICATE_REQUEST ->
-                "중복 승인 요청으로 카드사에서 거절했습니다.$raw"
-
-            PaymentTxFailureCode.INTERNAL_ERROR ->
-                "승인 처리 중 내부 오류가 발생했습니다.$raw"
         }
     }
 

--- a/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmStep2Writer.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmStep2Writer.kt
@@ -1,5 +1,7 @@
 package com.pgcore.core.application.usecase.command
 
+import com.pgcore.core.application.port.out.dto.CardApprovalResult
+import com.pgcore.core.application.port.out.dto.CardApprovalStatus
 import com.pgcore.core.application.repository.PaymentMutationRepository
 import com.pgcore.core.application.repository.PaymentRepository
 import com.pgcore.core.application.repository.PaymentTransactionRepository
@@ -31,35 +33,35 @@ class ConfirmStep2Writer(
     fun finalizeTransaction(
         command: ConfirmPaymentCommand,
         txId: Long,
-        isSuccess: Boolean,
-        providerTxId: String?,
-        failureCode: String?
+        approvalResult: CardApprovalResult
     ): PaymentTransaction {
         val transaction = paymentTransactionRepository.findById(txId)
             ?: throw BusinessException(PaymentErrorCode.PAYMENT_TX_NOT_FOUND)
 
-        return if (isSuccess) {
-            // CAS 방식으로 결제 상태 선점 (IN_PROGRESS -> DONE)
-            val affectedRows = paymentMutationRepository.finalizeApproveSuccess(command.paymentKey)
+        with(approvalResult) {
+            return if (status == CardApprovalStatus.SUCCESS) {
+                // CAS 방식으로 결제 상태 선점 (IN_PROGRESS -> DONE)
+                val affectedRows = paymentMutationRepository.finalizeApproveSuccess(command.paymentKey)
 
-            if (affectedRows == 0) {
-                handleStateMismatch(command, transaction, true, providerTxId, failureCode)
+                if (affectedRows == 0) {
+                    handleStateMismatch(command, transaction, true, providerTxId, failureCode)
+                } else {
+                    transaction.markSuccess(providerTxId)
+                    paymentTransactionRepository.saveAndFlush(transaction)
+                }
             } else {
-                transaction.markSuccess(providerTxId)
-                paymentTransactionRepository.saveAndFlush(transaction)
-            }
-        } else {
-            // CAS 방식으로 결제 상태 선점 (IN_PROGRESS -> ABORTED)
-            val affectedRows = paymentMutationRepository.finalizeApproveFail(command.paymentKey)
+                // CAS 방식으로 결제 상태 선점 (IN_PROGRESS -> ABORTED)
+                val affectedRows = paymentMutationRepository.finalizeApproveFail(command.paymentKey)
 
-            if (affectedRows == 0) {
-                handleStateMismatch(command, transaction, false, providerTxId, failureCode)
-            } else {
-                val mappedCode = PaymentTxFailureCode.fromRawCode(failureCode)
-                val reason = mappedCode.buildReason(failureCode)
+                if (affectedRows == 0) {
+                    handleStateMismatch(command, transaction, false, providerTxId, failureCode)
+                } else {
+                    val mappedCode = PaymentTxFailureCode.fromRawCode(failureCode)
+                    val reason = mappedCode.buildReason(failureCode)
 
-                transaction.markFail(mappedCode, reason)
-                paymentTransactionRepository.saveAndFlush(transaction)
+                    transaction.markFail(mappedCode, reason)
+                    paymentTransactionRepository.saveAndFlush(transaction)
+                }
             }
         }
     }
@@ -116,7 +118,11 @@ class ConfirmStep2Writer(
             }
 
             else -> {
-                transaction.markUnknown()
+                if (isPgSuccess == true) {
+                    transaction.markNeedNetCancel(providerTxId)
+                } else {
+                    transaction.markUnknown()
+                }
                 paymentTransactionRepository.saveAndFlush(transaction)
                 throw BusinessException(PaymentErrorCode.INTERNAL_ERROR)
             }
@@ -132,7 +138,7 @@ class ConfirmStep2Writer(
     fun handleExceptionAndMarkUnknown(
         command: ConfirmPaymentCommand,
         txId: Long,
-        isPgSuccess: Boolean?,
+        approvalStatus: CardApprovalStatus?,
         providerTxId: String?
     ) {
         // 1) payments CAS: IN_PROGRESS → UNKNOWN
@@ -146,9 +152,9 @@ class ConfirmStep2Writer(
             PaymentTxStatus.SUCCESS,
             PaymentTxStatus.FAIL,
             PaymentTxStatus.UNKNOWN -> return
-            else -> {
+            PaymentTxStatus.PENDING -> {
                 // PG사에서는 승인 성공했으나 DB 반영 중 에러가 났다면 망취소 대상으로 플래그 ON
-                if (isPgSuccess == true) {
+                if (approvalStatus == CardApprovalStatus.SUCCESS) {
                     transaction.markNeedNetCancel(providerTxId)
                 } else {
                     // 통신 타임아웃 등으로 결과를 아예 모르거나(null), 실패했다면 일반 UNKNOWN 마킹

--- a/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmStep2Writer.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmStep2Writer.kt
@@ -1,0 +1,192 @@
+package com.pgcore.core.application.usecase.command
+
+import com.pgcore.core.application.repository.PaymentMutationRepository
+import com.pgcore.core.application.repository.PaymentRepository
+import com.pgcore.core.application.repository.PaymentTransactionRepository
+import com.pgcore.core.application.usecase.command.dto.ConfirmPaymentCommand
+import com.pgcore.core.domain.enums.PaymentStatus
+import com.pgcore.core.domain.exception.PaymentErrorCode
+import com.pgcore.core.domain.payment.PaymentTransaction
+import com.pgcore.core.domain.payment.PaymentTxFailureCode
+import com.pgcore.core.domain.payment.PaymentTxStatus
+import com.pgcore.core.exception.BusinessException
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class ConfirmStep2Writer(
+    private val paymentRepository: PaymentRepository,
+    private val paymentMutationRepository: PaymentMutationRepository,
+    private val paymentTransactionRepository: PaymentTransactionRepository
+) {
+
+    /**
+     * Step2 확정 반영 (TX-2)
+     * - 성공: IN_PROGRESS -> DONE (CAS)
+     * - 실패: IN_PROGRESS -> ABORTED (CAS)
+     * - CAS 실패면 PG 원장 조회 후 원장 상태 기준 멱등 수렴
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun finalizeTransaction(
+        command: ConfirmPaymentCommand,
+        txId: Long,
+        isSuccess: Boolean,
+        providerTxId: String?,
+        failureCode: String?
+    ): PaymentTransaction {
+        val transaction = paymentTransactionRepository.findById(txId)
+            ?: throw BusinessException(PaymentErrorCode.PAYMENT_TX_NOT_FOUND)
+
+        return if (isSuccess) {
+            // CAS 방식으로 결제 상태 선점 (IN_PROGRESS -> DONE)
+            val affectedRows = paymentMutationRepository.finalizeApproveSuccess(command.paymentKey)
+
+            if (affectedRows == 0) {
+                handleStateMismatch(command, transaction, true, providerTxId, failureCode)
+            } else {
+                transaction.markSuccess(providerTxId)
+                paymentTransactionRepository.saveAndFlush(transaction)
+            }
+        } else {
+            // CAS 방식으로 결제 상태 선점 (IN_PROGRESS -> ABORTED)
+            val affectedRows = paymentMutationRepository.finalizeApproveFail(command.paymentKey)
+
+            if (affectedRows == 0) {
+                handleStateMismatch(command, transaction, false, providerTxId, failureCode)
+            } else {
+                val mappedCode = mapFailureCode(failureCode)
+                val reason = buildFailureReason(mappedCode, failureCode)
+
+                transaction.markFail(mappedCode, reason)
+                paymentTransactionRepository.saveAndFlush(transaction)
+            }
+        }
+    }
+
+    private fun handleStateMismatch(
+        command: ConfirmPaymentCommand,
+        transaction: PaymentTransaction,
+        isPgSuccess: Boolean?,
+        providerTxId: String?,
+        failureCode: String?
+    ): PaymentTransaction {
+        // 1. 최신 원장(Payment) 상태 조회
+        val payment = paymentRepository.findByPaymentKey(command.paymentKey)
+            ?: throw BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND)
+
+        // 2. "원장 상태"를 기준으로 트랜잭션 이력 수렴
+        return when (payment.status) {
+            PaymentStatus.DONE -> {
+                if (transaction.status == PaymentTxStatus.SUCCESS) {
+                    transaction
+                } else {
+                    transaction.markSuccess(providerTxId)
+                    paymentTransactionRepository.saveAndFlush(transaction)
+                }
+            }
+
+            PaymentStatus.ABORTED -> {
+                // 카드사는 성공했는데 PG 원장은 ABORTED
+                if (isPgSuccess == true) {
+                    transaction.markNeedNetCancel(providerTxId)
+                    paymentTransactionRepository.saveAndFlush(transaction)
+                    throw BusinessException(PaymentErrorCode.PAYMENT_STATE_MISMATCH)
+                }
+
+                // 카드사도 실패했는데 PG 원장은 ABORTED → 그냥 수렴
+                when (transaction.status) {
+                    PaymentTxStatus.FAIL -> transaction
+                    else -> {
+                        val mapped = mapFailureCode(failureCode)
+                        val reason = buildFailureReason(mapped, failureCode)
+                        transaction.markFail(mapped, reason)
+                        paymentTransactionRepository.saveAndFlush(transaction)
+                    }
+                }
+            }
+
+            PaymentStatus.UNKNOWN -> {
+                if (transaction.status == PaymentTxStatus.UNKNOWN) {
+                    transaction
+                } else {
+                    transaction.markUnknown()
+                    paymentTransactionRepository.saveAndFlush(transaction)
+                }
+            }
+
+            else -> {
+                transaction.markUnknown()
+                paymentTransactionRepository.saveAndFlush(transaction)
+                throw BusinessException(PaymentErrorCode.INTERNAL_ERROR)
+            }
+        }
+    }
+
+    private fun mapFailureCode(rawFailureCode: String?): PaymentTxFailureCode =
+        rawFailureCode
+            ?.takeIf { it.isNotBlank() }
+            ?.let { runCatching { PaymentTxFailureCode.valueOf(it) }.getOrNull() }
+            ?: PaymentTxFailureCode.INTERNAL_ERROR
+
+    private fun buildFailureReason(code: PaymentTxFailureCode, rawFailureCode: String?): String {
+        val raw = rawFailureCode?.let { " (code=$it)" } ?: ""
+        return when (code) {
+            PaymentTxFailureCode.CARD_BLOCKED ->
+                "카드 사용이 정지(분실/도난 신고 또는 이용 제한)되어 승인에 실패했습니다.$raw"
+
+            PaymentTxFailureCode.CARD_EXPIRED ->
+                "카드 유효기간 만료로 승인에 실패했습니다.$raw"
+
+            PaymentTxFailureCode.INSUFFICIENT_FUNDS ->
+                "잔액 부족으로 승인에 실패했습니다.$raw"
+
+            PaymentTxFailureCode.LIMIT_EXCEEDED ->
+                "한도 초과로 승인에 실패했습니다.$raw"
+
+            PaymentTxFailureCode.INVALID_CARD ->
+                "유효하지 않은 카드 정보로 승인에 실패했습니다.$raw"
+
+            PaymentTxFailureCode.INVALID_PIN_OR_CVC ->
+                "비밀번호(PIN) 또는 CVC 오류로 승인에 실패했습니다.$raw"
+
+            PaymentTxFailureCode.FRAUD_SUSPECTED ->
+                "부정 사용 의심으로 카드사에서 승인을 거절했습니다.$raw"
+
+            PaymentTxFailureCode.MERCHANT_NOT_ALLOWED ->
+                "해당 가맹점에서는 사용이 허용되지 않아 승인에 실패했습니다.$raw"
+
+            PaymentTxFailureCode.DUPLICATE_REQUEST ->
+                "중복 승인 요청으로 카드사에서 거절했습니다.$raw"
+
+            PaymentTxFailureCode.INTERNAL_ERROR ->
+                "승인 처리 중 내부 오류가 발생했습니다.$raw"
+        }
+    }
+
+    /**
+     * provider 호출 중 예외(타임아웃/네트워크 장애 등) 발생 시 호출
+     * - payments: IN_PROGRESS → UNKNOWN (CAS UPDATE)
+     * - payment_transactions: 해당 tx → UNKNOWN
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun markAsUnknown(command: ConfirmPaymentCommand, txId: Long) {
+        // 1) payments CAS: IN_PROGRESS → UNKNOWN
+        // affectedRows == 0 이면 이미 다른 경로로 상태가 바뀐 것 → 그대로 둠
+        paymentMutationRepository.markUnknown(command.paymentKey)
+
+        // 2) payment_transactions 상태 UNKNOWN 마킹
+        val transaction = paymentTransactionRepository.findById(txId) ?: return
+
+        when (transaction.status) {
+            PaymentTxStatus.SUCCESS,
+            PaymentTxStatus.FAIL,
+            PaymentTxStatus.UNKNOWN -> return
+
+            else -> {
+                transaction.markUnknown()
+                paymentTransactionRepository.saveAndFlush(transaction)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmStep2Writer.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/command/ConfirmStep2Writer.kt
@@ -129,7 +129,12 @@ class ConfirmStep2Writer(
      * - payment_transactions: 해당 tx → UNKNOWN
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    fun markAsUnknown(command: ConfirmPaymentCommand, txId: Long) {
+    fun handleExceptionAndMarkUnknown(
+        command: ConfirmPaymentCommand,
+        txId: Long,
+        isPgSuccess: Boolean?,
+        providerTxId: String?
+    ) {
         // 1) payments CAS: IN_PROGRESS → UNKNOWN
         // affectedRows == 0 이면 이미 다른 경로로 상태가 바뀐 것 → 그대로 둠
         paymentMutationRepository.markUnknown(command.paymentKey)
@@ -141,9 +146,14 @@ class ConfirmStep2Writer(
             PaymentTxStatus.SUCCESS,
             PaymentTxStatus.FAIL,
             PaymentTxStatus.UNKNOWN -> return
-
             else -> {
-                transaction.markUnknown()
+                // PG사에서는 승인 성공했으나 DB 반영 중 에러가 났다면 망취소 대상으로 플래그 ON
+                if (isPgSuccess == true) {
+                    transaction.markNeedNetCancel(providerTxId)
+                } else {
+                    // 통신 타임아웃 등으로 결과를 아예 모르거나(null), 실패했다면 일반 UNKNOWN 마킹
+                    transaction.markUnknown()
+                }
                 paymentTransactionRepository.saveAndFlush(transaction)
             }
         }

--- a/src/main/kotlin/com/pgcore/core/application/usecase/command/dto/ConfirmPaymentCommand.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/command/dto/ConfirmPaymentCommand.kt
@@ -1,0 +1,10 @@
+package com.pgcore.core.application.usecase.command.dto
+
+data class ConfirmPaymentCommand(
+    val paymentKey: String,
+    val merchantId: Long,
+    val idempotencyKey: String,
+    val orderId: String,
+    val amount: Long,
+    val billingKey: String
+)

--- a/src/main/kotlin/com/pgcore/core/application/usecase/command/dto/ConfirmPaymentResult.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/command/dto/ConfirmPaymentResult.kt
@@ -2,9 +2,8 @@ package com.pgcore.core.application.usecase.command.dto
 
 import com.pgcore.core.domain.enums.PaymentStatus
 import com.pgcore.core.domain.payment.PaymentTransaction
-import com.pgcore.core.domain.payment.PaymentTxStatus
 
-data class ConfirmPaymentResult(
+data class ConfirmPaymentResult private constructor(
     val paymentKey: String,
     val status: PaymentStatus,
     val amount: Long,
@@ -12,15 +11,9 @@ data class ConfirmPaymentResult(
 ) {
     companion object {
         fun from(transaction: PaymentTransaction, paymentKey: String): ConfirmPaymentResult {
-            val mappedStatus = when (transaction.status) {
-                PaymentTxStatus.SUCCESS -> PaymentStatus.DONE
-                PaymentTxStatus.FAIL -> PaymentStatus.ABORTED
-                PaymentTxStatus.UNKNOWN, PaymentTxStatus.PENDING -> PaymentStatus.UNKNOWN
-            }
-
             return ConfirmPaymentResult(
                 paymentKey = paymentKey,
-                status = mappedStatus,
+                status = transaction.status.toPaymentStatus(),
                 amount = transaction.requestedAmount.amount,
                 providerTxId = transaction.providerTxId
             )

--- a/src/main/kotlin/com/pgcore/core/application/usecase/command/dto/ConfirmPaymentResult.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/command/dto/ConfirmPaymentResult.kt
@@ -1,0 +1,29 @@
+package com.pgcore.core.application.usecase.command.dto
+
+import com.pgcore.core.domain.enums.PaymentStatus
+import com.pgcore.core.domain.payment.PaymentTransaction
+import com.pgcore.core.domain.payment.PaymentTxStatus
+
+data class ConfirmPaymentResult(
+    val paymentKey: String,
+    val status: PaymentStatus,
+    val amount: Long,
+    val providerTxId: String?
+) {
+    companion object {
+        fun from(transaction: PaymentTransaction, paymentKey: String): ConfirmPaymentResult {
+            val mappedStatus = when (transaction.status) {
+                PaymentTxStatus.SUCCESS -> PaymentStatus.DONE
+                PaymentTxStatus.FAIL -> PaymentStatus.ABORTED
+                PaymentTxStatus.UNKNOWN, PaymentTxStatus.PENDING -> PaymentStatus.UNKNOWN
+            }
+
+            return ConfirmPaymentResult(
+                paymentKey = paymentKey,
+                status = mappedStatus,
+                amount = transaction.requestedAmount.amount,
+                providerTxId = transaction.providerTxId
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/pgcore/core/common/HashUtils.kt
+++ b/src/main/kotlin/com/pgcore/core/common/HashUtils.kt
@@ -1,0 +1,11 @@
+package com.pgcore.core.common
+
+import java.security.MessageDigest
+
+object HashUtils {
+    fun sha256Hex(bytes: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return digest.digest(bytes)
+            .joinToString("") { "%02x".format(it) }
+    }
+}

--- a/src/main/kotlin/com/pgcore/core/common/PaymentKeyGenerator.kt
+++ b/src/main/kotlin/com/pgcore/core/common/PaymentKeyGenerator.kt
@@ -1,0 +1,7 @@
+package com.pgcore.core.common
+
+import java.util.UUID
+
+object PaymentKeyGenerator {
+    fun generate(): String = "pay_" + UUID.randomUUID().toString().replace("-", "")
+}

--- a/src/main/kotlin/com/pgcore/core/domain/enums/PaymentStatus.kt
+++ b/src/main/kotlin/com/pgcore/core/domain/enums/PaymentStatus.kt
@@ -73,4 +73,17 @@ enum class PaymentStatus {
             throw BusinessException(PaymentErrorCode.PAYMENT_NOT_CANCELLABLE)
         }
     }
+
+    fun toConfirmException(): BusinessException = when (this) {
+        // 결제 유효기간 만료 → 새 결제로 재시도 유도
+        EXPIRED -> BusinessException(PaymentErrorCode.PAYMENT_EXPIRED)
+        // 이미 누군가 선점하고 처리 중
+        IN_PROGRESS -> BusinessException(PaymentErrorCode.IDEMPOTENCY_PROCESSING)
+        // 이미 최종 완료/실패로 끝난 결제
+        DONE, ABORTED, CANCEL, PARTIAL_CANCEL -> BusinessException(PaymentErrorCode.ALREADY_PROCESSED)
+        // 확정불가(망취소 대기/UNKNOWN)는 재시도를 막고 조회/대사로 유도하는 게 안전
+        UNKNOWN -> BusinessException(PaymentErrorCode.IDEMPOTENCY_RETRY_BLOCKED)
+        // READY로 보이지만 CAS가 실패했다면 레이스/읽기 불일치/상태 꼬임 가능성이 있어 안전하게 STATE_LOST로 처리
+        READY -> BusinessException(PaymentErrorCode.IDEMPOTENCY_STATE_LOST)
+    }
 }

--- a/src/main/kotlin/com/pgcore/core/domain/exception/PaymentErrorCode.kt
+++ b/src/main/kotlin/com/pgcore/core/domain/exception/PaymentErrorCode.kt
@@ -13,12 +13,15 @@ enum class PaymentErrorCode(
     INVALID_PAYMENT_KEY(HttpStatus.BAD_REQUEST, "PAY-0001", "결제 키는 비어 있을 수 없습니다."),
     INVALID_ORDER_ID(HttpStatus.BAD_REQUEST, "PAY-0002", "주문 번호는 비어 있을 수 없습니다."),
     INVALID_TOTAL_AMOUNT(HttpStatus.BAD_REQUEST, "PAY-0003", "결제 금액은 0보다 커야 합니다."),
+    PAYMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "PAY-0004", "해당 결제 키에 대한 결제를 찾을 수 없습니다."),
+    PAYMENT_TX_NOT_FOUND(HttpStatus.BAD_REQUEST, "PAY-0005", "해당 트랜잭션 ID에 대한 결제 이력을 찾을 수 없습니다."),
 
     // ===== 상태 전이 오류 =====
     INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "PAY-0101", "현재 상태에서 허용되지 않는 결제 상태 변경입니다."),
     PAYMENT_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "PAY-0102", "이미 완료된 결제입니다."),
     PAYMENT_NOT_COMPLETABLE(HttpStatus.BAD_REQUEST, "PAY-0103", "결제를 완료할 수 없는 상태입니다."),
     PAYMENT_NOT_CANCELLABLE(HttpStatus.BAD_REQUEST, "PAY-0104", "취소할 수 없는 결제 상태입니다."),
+    PAYMENT_EXPIRED(HttpStatus.CONFLICT, "PAY-0105", "결제 유효기간이 만료되었습니다. 새로운 결제로 다시 시도해 주세요."),
 
     // ===== 금액 관련 =====
     INVALID_CANCEL_AMOUNT(HttpStatus.BAD_REQUEST, "PAY-0201", "취소 금액은 0보다 커야 합니다."),
@@ -35,4 +38,23 @@ enum class PaymentErrorCode(
     DUPLICATE_ORDER_ID_NAME_MISMATCH(HttpStatus.CONFLICT, "PAY-0403", "동일한 주문 번호로 다른 주문명의 결제를 생성할 수 없습니다."),
     ORDER_ID_NOT_READY(HttpStatus.CONFLICT, "PAY-0404", "이미 처리 중이거나 처리된 주문 번호입니다. 결제 조회/승인/취소 API를 사용해주세요."),
     ORDER_ID_EXPIRED(HttpStatus.CONFLICT, "PAY-0405", "이 주문번호는 이미 만료되었습니다. 새로운 주문번호로 시도하세요."),
+
+    // ===== 승인/원장 크로스 체크(Confirm 전용) =====
+    REQUEST_TOTAL_AMOUNT_MISMATCH(HttpStatus.CONFLICT, "PAY-0501", "요청된 금액과 결제 원장의 금액이 일치하지 않습니다."),
+    REQUEST_ORDER_ID_MISMATCH(HttpStatus.CONFLICT, "PAY-0502", "요청된 주문 번호와 결제 원장의 주문 번호가 일치하지 않습니다."),
+    ALREADY_PROCESSED(HttpStatus.CONFLICT, "PAY-0503", "이미 성공 또는 실패 처리된 결제입니다."),
+    PAYMENT_STATE_MISMATCH(HttpStatus.CONFLICT, "PAY-0504", "결제 원장 불일치: PG 승인 상태와 시스템 원장 상태가 다릅니다. (대사/망취소 대상)"),
+
+    // ===== 멱등성 (Idempotency) 관련 오류 =====
+    IDEMPOTENCY_KEY_MISSING(HttpStatus.BAD_REQUEST, "PAY-0601", "Idempotency-Key 헤더는 필수입니다."),
+    IDEMPOTENCY_PROCESSING(HttpStatus.CONFLICT, "PAY-0602", "동일한 요청이 현재 처리 중입니다."),
+    IDEMPOTENCY_DATA_MISMATCH(HttpStatus.CONFLICT, "PAY-0603", "멱등키의 요청 데이터가 일치하지 않습니다. (데이터 변조 의심)"),
+    IDEMPOTENCY_STATE_LOST(HttpStatus.CONFLICT, "PAY-0604", "동시 요청 처리 중 상태가 유실되었거나 일시적인 지연이 발생했습니다. 결제 내역을 먼저 확인해 주세요."),
+    IDEMPOTENCY_RETRY_BLOCKED(HttpStatus.CONFLICT, "PAY-0605", "이전 요청 처리 중 서버 오류가 발생하여 재시도가 차단되었습니다. 망취소 대기 중일 수 있으니 결제 상태(단건 조회 API)를 먼저 확인해 주세요."),
+
+    // ===== 외부 API 통신 오류 =====
+    EMPTY_PROVIDER_RESPONSE(HttpStatus.BAD_GATEWAY, "PAY-0701", "결제 승인 API 응답값이 비어 있습니다."),
+
+    // ===== 시스템 공통 =====
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "PAY-9999", "서버 내부 오류가 발생했습니다.")
 }

--- a/src/main/kotlin/com/pgcore/core/domain/payment/PaymentTransaction.kt
+++ b/src/main/kotlin/com/pgcore/core/domain/payment/PaymentTransaction.kt
@@ -1,5 +1,6 @@
 package com.pgcore.core.domain.payment
 
+import com.pgcore.core.domain.enums.PaymentStatus
 import com.pgcore.core.domain.exception.PaymentTransactionErrorCode
 import com.pgcore.core.domain.payment.vo.Money
 import com.pgcore.core.exception.BusinessException
@@ -207,6 +208,12 @@ enum class PaymentTxStatus {
     UNKNOWN,;
 
     fun isRetryable(): Boolean = this == PENDING || this == UNKNOWN
+
+    fun toPaymentStatus(): PaymentStatus = when (this) {
+        SUCCESS -> PaymentStatus.DONE
+        FAIL -> PaymentStatus.ABORTED
+        UNKNOWN, PENDING -> PaymentStatus.UNKNOWN
+    }
 }
 
 enum class PaymentTxFailureCode(val defaultMessage: String) {

--- a/src/main/kotlin/com/pgcore/core/domain/payment/PaymentTransaction.kt
+++ b/src/main/kotlin/com/pgcore/core/domain/payment/PaymentTransaction.kt
@@ -209,15 +209,28 @@ enum class PaymentTxStatus {
     fun isRetryable(): Boolean = this == PENDING || this == UNKNOWN
 }
 
-enum class PaymentTxFailureCode {
-    CARD_BLOCKED,
-    CARD_EXPIRED,
-    INSUFFICIENT_FUNDS,
-    LIMIT_EXCEEDED,
-    INVALID_CARD,
-    INVALID_PIN_OR_CVC,
-    FRAUD_SUSPECTED,
-    MERCHANT_NOT_ALLOWED,
-    DUPLICATE_REQUEST,
-    INTERNAL_ERROR,
+enum class PaymentTxFailureCode(val defaultMessage: String) {
+    CARD_BLOCKED("카드 사용이 정지(분실/도난 신고 또는 이용 제한)되어 승인에 실패했습니다."),
+    CARD_EXPIRED("카드 유효기간 만료로 승인에 실패했습니다."),
+    INSUFFICIENT_FUNDS("잔액 부족으로 승인에 실패했습니다."),
+    LIMIT_EXCEEDED("한도 초과로 승인에 실패했습니다."),
+    INVALID_CARD("유효하지 않은 카드 정보로 승인에 실패했습니다."),
+    INVALID_PIN_OR_CVC("비밀번호(PIN) 또는 CVC 오류로 승인에 실패했습니다."),
+    FRAUD_SUSPECTED("부정 사용 의심으로 카드사에서 승인을 거절했습니다."),
+    MERCHANT_NOT_ALLOWED("해당 가맹점에서는 사용이 허용되지 않아 승인에 실패했습니다."),
+    DUPLICATE_REQUEST("중복 승인 요청으로 카드사에서 거절했습니다."),
+    INTERNAL_ERROR("승인 처리 중 내부 오류가 발생했습니다.");
+
+    fun buildReason(rawCode: String?): String {
+        val suffix = rawCode?.let { " (code=$it)" } ?: ""
+        return this.defaultMessage + suffix
+    }
+
+    companion object {
+        fun fromRawCode(rawFailureCode: String?): PaymentTxFailureCode =
+            rawFailureCode
+                ?.takeIf { it.isNotBlank() }
+                ?.let { runCatching { valueOf(it) }.getOrNull() }
+                ?: INTERNAL_ERROR
+    }
 }

--- a/src/main/kotlin/com/pgcore/core/domain/payment/PaymentTransaction.kt
+++ b/src/main/kotlin/com/pgcore/core/domain/payment/PaymentTransaction.kt
@@ -55,7 +55,7 @@ class PaymentTransaction protected constructor(
     val requestedAmount: Money,
 
     @Column(name = "pg_tx_id", length = 80)
-    var pgTxId: String? = null,
+    var providerTxId: String? = null,
 
     @Column(name = "idempotency_key", length = 80, nullable = false, updatable = false)
     val idempotencyKey: String,
@@ -72,6 +72,10 @@ class PaymentTransaction protected constructor(
     var failureMessage: String? = null
         protected set
 
+    @Column(name = "need_net_cancel", nullable = false)
+    var needNetCancel: Boolean = false
+        protected set
+
     @Column(name = "attempt_count", nullable = false)
     var attemptCount: Int = 0
         protected set
@@ -85,7 +89,7 @@ class PaymentTransaction protected constructor(
         protected set
 
     @Column(name = "updated_at", nullable = false)
-    var updatedAt: LocalDateTime? = null
+    var updatedAt: LocalDateTime = LocalDateTime.now()
         protected set
 
     companion object {
@@ -141,11 +145,11 @@ class PaymentTransaction protected constructor(
     }
 
     fun markSuccess(
-        pgTxId: String?,
+        providerTxId: String?,
         confirmedAt: LocalDateTime = LocalDateTime.now(),
     ) {
         this.status = PaymentTxStatus.SUCCESS
-        this.pgTxId = pgTxId
+        this.providerTxId = providerTxId
         this.confirmedAt = confirmedAt
         this.failureCode = null
         this.failureMessage = null
@@ -167,6 +171,19 @@ class PaymentTransaction protected constructor(
     ) {
         this.status = PaymentTxStatus.UNKNOWN
         this.nextAttemptAt = nextAttemptAt
+    }
+
+    /**
+     * [치명 불일치 발생 시 호출]
+     * PG사는 승인(Success)되었으나 시스템 원장이 ABORTED 되어 정상적인 반영이 불가능한 경우.
+     * 대사(Reconciliation) 배치가 이 건을 발견하고 PG사에 망취소를 요청할 수 있도록 플래그를 켭니다.
+     */
+    fun markNeedNetCancel(providerTxId: String?) {
+        this.status = PaymentTxStatus.UNKNOWN // 상태는 대사 대상인 UNKNOWN으로 마킹
+        this.providerTxId = providerTxId                  // 망취소 시 반드시 필요하므로 멱살 잡고 저장!
+        this.needNetCancel = true             // 배치 프로그램이 긁어갈 플래그 ON
+        this.failureCode = PaymentTxFailureCode.INTERNAL_ERROR
+        this.failureMessage = "원장 확정 실패(ABORTED)로 인한 망취소 대기"
     }
 
     fun bumpAttempt(nextAttemptAt: LocalDateTime? = null) {

--- a/src/main/kotlin/com/pgcore/core/domain/payment/vo/Money.kt
+++ b/src/main/kotlin/com/pgcore/core/domain/payment/vo/Money.kt
@@ -6,7 +6,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Embeddable
 
 @Embeddable
-class Money(
+data class Money(
     @Column(nullable = false)
     val amount: Long,
 ): Comparable<Money> {
@@ -29,17 +29,4 @@ class Money(
     }
 
     fun isZero(): Boolean = amount == 0L
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as Money
-
-        return amount == other.amount
-    }
-
-    override fun hashCode(): Int {
-        return amount.hashCode()
-    }
 }

--- a/src/main/kotlin/com/pgcore/core/domain/payment/vo/Money.kt
+++ b/src/main/kotlin/com/pgcore/core/domain/payment/vo/Money.kt
@@ -29,4 +29,17 @@ class Money(
     }
 
     fun isZero(): Boolean = amount == 0L
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Money
+
+        return amount == other.amount
+    }
+
+    override fun hashCode(): Int {
+        return amount.hashCode()
+    }
 }

--- a/src/main/kotlin/com/pgcore/core/infra/adapter/out/card/CardApprovalGatewayHttpClient.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/adapter/out/card/CardApprovalGatewayHttpClient.kt
@@ -1,0 +1,85 @@
+package com.pgcore.core.infra.adapter.out.card
+
+import com.pgcore.core.application.port.out.CardApprovalGateway
+import com.pgcore.core.application.port.out.dto.CardApprovalResult
+import com.pgcore.core.domain.exception.PaymentErrorCode
+import com.pgcore.core.exception.BusinessException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+import java.time.Duration
+
+@Component
+class CardApprovalGatewayHttpClient(
+    restTemplateBuilder: RestTemplateBuilder,
+    @Value("\${mock-card-server.url:http://localhost:8081}") private val mockServerUrl: String
+) : CardApprovalGateway {
+
+    // 가이드라인 적용: 외부 통신 지연으로 인한 스레드 고갈을 막기 위한 타임아웃 강제 설정
+    private val restTemplate: RestTemplate = restTemplateBuilder
+        .connectTimeout(Duration.ofSeconds(1)) // 커넥션 타임아웃 1초
+        .readTimeout(Duration.ofSeconds(3))    // 리드 타임아웃 3초
+        .build()
+
+    /**
+     * 목카드 서버(card-service)로 전송할 내부 전용 DTO
+     */
+    data class MockApproveRequest(
+        val providerRequestId: String,
+        val merchantId: String,
+        val orderId: String,
+        val amount: Long,
+        val billingKey: String
+    )
+
+    /**
+     * 목카드 서버(card-service)로부터 받을 내부 전용 응답 DTO
+     */
+    data class MockCardResponse(
+        val providerRequestId: String,
+        val status: String,           // "SUCCESS" or "FAIL"
+        val providerTxId: String?,    // null 가능 (실패 시)
+        val amount: Long,
+        val failureCode: String?,     // null 가능 (성공 시)
+        val processedAt: String
+    )
+
+    override fun approve(
+        providerRequestId: String,
+        merchantId: String,
+        orderId: String,
+        billingKey: String,
+        amount: Long
+    ): CardApprovalResult {
+        val url = "$mockServerUrl/provider/approve"
+
+        val requestDto = MockApproveRequest(
+            providerRequestId = providerRequestId,
+            merchantId = merchantId,
+            orderId = orderId,
+            amount = amount,
+            billingKey = billingKey
+        )
+
+        val headers = HttpHeaders().apply {
+            contentType = MediaType.APPLICATION_JSON
+        }
+
+        val entity = HttpEntity(requestDto, headers)
+
+        // 이 구간에서 3초 이상 응답이 없으면 RestClientException(하위 SocketTimeoutException)이 발생하며,
+        // 이 예외는 ConfirmPaymentUseCase에서 캐치되어 UNKNOWN 처리 및 망취소 로직으로 넘어갑니다.
+        val response = restTemplate.postForObject(url, entity, MockCardResponse::class.java)
+            ?: throw BusinessException(PaymentErrorCode.EMPTY_PROVIDER_RESPONSE)
+
+        return CardApprovalResult(
+            isSuccess = response.status == "SUCCESS",
+            providerTxId = response.providerTxId,
+            failureCode = response.failureCode
+        )
+    }
+}

--- a/src/main/kotlin/com/pgcore/core/infra/adapter/out/card/CardApprovalGatewayHttpClient.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/adapter/out/card/CardApprovalGatewayHttpClient.kt
@@ -2,6 +2,7 @@ package com.pgcore.core.infra.adapter.out.card
 
 import com.pgcore.core.application.port.out.CardApprovalGateway
 import com.pgcore.core.application.port.out.dto.CardApprovalResult
+import com.pgcore.core.application.port.out.dto.CardApprovalStatus
 import com.pgcore.core.domain.exception.PaymentErrorCode
 import com.pgcore.core.exception.BusinessException
 import org.springframework.beans.factory.annotation.Value
@@ -16,7 +17,7 @@ import java.time.Duration
 @Component
 class CardApprovalGatewayHttpClient(
     restTemplateBuilder: RestTemplateBuilder,
-    @Value("\${mock-card-server.url:http://localhost:8081}") private val mockServerUrl: String
+    @Value("\${mock-card-server.url}") private val mockServerUrl: String
 ) : CardApprovalGateway {
 
     // 가이드라인 적용: 외부 통신 지연으로 인한 스레드 고갈을 막기 위한 타임아웃 강제 설정
@@ -27,6 +28,11 @@ class CardApprovalGatewayHttpClient(
 
     /**
      * 목카드 서버(card-service)로 전송할 내부 전용 DTO
+     * @param providerRequestId: 요청 ID (TX ID 활용)
+     * @param merchantId: 가맹점 ID
+     * @param orderId: 주문 ID
+     * @param amount: 요청 금액
+     * @param billingKey: 빌링키
      */
     data class MockApproveRequest(
         val providerRequestId: String,
@@ -38,13 +44,19 @@ class CardApprovalGatewayHttpClient(
 
     /**
      * 목카드 서버(card-service)로부터 받을 내부 전용 응답 DTO
+     * @param providerRequestId: 요청 ID (TX ID 활용)
+     * @param status: "SUCCESS" 또는 "FAIL"
+     * @param providerTxId: PG사 거래 ID (성공 시), 실패 시 null
+     * @param amount: 요청 금액
+     * @param failureCode: 실패 코드 (실패 시), 성공 시 null
+     * @param processedAt: 처리 시각
      */
     data class MockCardResponse(
         val providerRequestId: String,
-        val status: String,           // "SUCCESS" or "FAIL"
-        val providerTxId: String?,    // null 가능 (실패 시)
+        val status: String,
+        val providerTxId: String?,
         val amount: Long,
-        val failureCode: String?,     // null 가능 (성공 시)
+        val failureCode: String?,
         val processedAt: String
     )
 
@@ -76,8 +88,14 @@ class CardApprovalGatewayHttpClient(
         val response = restTemplate.postForObject(url, entity, MockCardResponse::class.java)
             ?: throw BusinessException(PaymentErrorCode.EMPTY_PROVIDER_RESPONSE)
 
+        val approvalStatus = if (response.status == "SUCCESS") {
+            CardApprovalStatus.SUCCESS
+        } else {
+            CardApprovalStatus.FAIL
+        }
+
         return CardApprovalResult(
-            isSuccess = response.status == "SUCCESS",
+            status = approvalStatus,
             providerTxId = response.providerTxId,
             failureCode = response.failureCode
         )

--- a/src/main/kotlin/com/pgcore/core/infra/idempotency/CachedBodyHttpServletRequestWrapper.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/idempotency/CachedBodyHttpServletRequestWrapper.kt
@@ -1,0 +1,38 @@
+package com.pgcore.core.infra.idempotency
+
+import jakarta.servlet.ReadListener
+import jakarta.servlet.ServletInputStream
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequestWrapper
+import org.springframework.util.StreamUtils
+import java.io.ByteArrayInputStream
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+class CachedBodyHttpServletRequestWrapper(request: HttpServletRequest) : HttpServletRequestWrapper(request) {
+
+    // 1. 객체 생성 시점에 원본 스트림을 읽어서 byte 배열로 복사해 둡니다.
+    private val cachedBody: ByteArray = StreamUtils.copyToByteArray(request.inputStream)
+
+    fun getCachedBody(): ByteArray = cachedBody
+
+    // 2. getInputStream()이 호출될 때마다 복사해둔 byte 배열로 새로운 스트림을 만들어 반환합니다.
+    override fun getInputStream(): ServletInputStream {
+        return CachedBodyServletInputStream(cachedBody)
+    }
+
+    override fun getReader(): BufferedReader {
+        return BufferedReader(InputStreamReader(ByteArrayInputStream(cachedBody), characterEncoding ?: "UTF-8"))
+    }
+
+    // 커스텀 ServletInputStream 구현체
+    private class CachedBodyServletInputStream(cachedBody: ByteArray) : ServletInputStream() {
+        private val inputStream = ByteArrayInputStream(cachedBody)
+
+        override fun isFinished(): Boolean = inputStream.available() == 0
+        override fun isReady(): Boolean = true
+        override fun setReadListener(readListener: ReadListener?) {
+        }
+        override fun read(): Int = inputStream.read()
+    }
+}

--- a/src/main/kotlin/com/pgcore/core/infra/idempotency/IdempotencyData.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/idempotency/IdempotencyData.kt
@@ -3,8 +3,8 @@ package com.pgcore.core.infra.idempotency
 import java.io.Serializable
 
 data class IdempotencyData(
-    val status: String,        // "PROCESSING" or "DONE"
-    val requestHash: String,   // 위변조 방지용 페이로드 해시
-    val responseStatus: Int? = null, // 처리 완료 시 캐싱될 HTTP 응답 상태 코드
-    val responseBody: String? = null // 처리 완료 시 캐싱될 응답 본문
+    val status: IdempotencyStatus,
+    val requestHash: String,
+    val responseStatus: Int? = null,
+    val responseBody: String? = null
 ) : Serializable

--- a/src/main/kotlin/com/pgcore/core/infra/idempotency/IdempotencyData.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/idempotency/IdempotencyData.kt
@@ -1,0 +1,10 @@
+package com.pgcore.core.infra.idempotency
+
+import java.io.Serializable
+
+data class IdempotencyData(
+    val status: String,        // "PROCESSING" or "DONE"
+    val requestHash: String,   // 위변조 방지용 페이로드 해시
+    val responseStatus: Int? = null, // 처리 완료 시 캐싱될 HTTP 응답 상태 코드
+    val responseBody: String? = null // 처리 완료 시 캐싱될 응답 본문
+) : Serializable

--- a/src/main/kotlin/com/pgcore/core/infra/idempotency/IdempotencyFilter.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/idempotency/IdempotencyFilter.kt
@@ -1,37 +1,24 @@
 package com.pgcore.core.infra.idempotency
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.pgcore.core.domain.exception.PaymentErrorCode
 import com.pgcore.core.exception.BusinessException
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Component
 import org.springframework.util.AntPathMatcher
 import org.springframework.web.filter.OncePerRequestFilter
 import org.springframework.web.servlet.HandlerExceptionResolver
+import com.pgcore.core.common.HashUtils
 import org.springframework.web.util.ContentCachingResponseWrapper
-import java.security.MessageDigest
-import java.time.Duration
 
 @Component
 class IdempotencyFilter(
-    private val redisTemplate: StringRedisTemplate,
-    private val objectMapper: ObjectMapper,
+    private val idempotencyRedisRepository: IdempotencyRedisRepository,
     @Qualifier("handlerExceptionResolver") private val exceptionResolver: HandlerExceptionResolver
 ) : OncePerRequestFilter() {
 
-    companion object {
-        private const val IDEMPOTENCY_PREFIX = "idempotency:"
-        private const val STATUS_PROCESSING = "PROCESSING"
-        private const val STATUS_UNKNOWN = "UNKNOWN"
-        private const val STATUS_DONE = "DONE"
-        private val PROCESSING_TTL = Duration.ofMinutes(10)
-        private val UNKNOWN_TTL = Duration.ofMinutes(30)
-        private val DONE_TTL = Duration.ofHours(24)
-    }
 
     private val pathMatcher = AntPathMatcher()
     private val includePatterns = listOf(
@@ -55,7 +42,7 @@ class IdempotencyFilter(
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-        // 2. Idempotency-Key 헤더 추출 및 검증
+        // Idempotency-Key 헤더 추출 및 검증
         val idempotencyKey = request.getHeader("Idempotency-Key")
         if (idempotencyKey.isNullOrBlank()) {
             exceptionResolver.resolveException(
@@ -66,12 +53,12 @@ class IdempotencyFilter(
         }
 
         val cachedRequest = CachedBodyHttpServletRequestWrapper(request)
-        val requestHash = generateRequestHash(cachedRequest)
-        val redisKey = buildRedisKey(request, idempotencyKey)
+        val requestHash = HashUtils.sha256Hex(cachedRequest.getCachedBody())
+        val redisKey = idempotencyRedisRepository.buildRedisKey(request.method, request.requestURI, idempotencyKey)
 
         try {
-            // 3. Redis 락 획득 시도 (첫 요청인지 판별)
-            val isFirstRequest = tryAcquireProcessingLock(redisKey, requestHash)
+            // SETNX로 최초 요청 여부 판별
+            val isFirstRequest = idempotencyRedisRepository.acquireIfAbsent(redisKey, requestHash)
 
             if (isFirstRequest) {
                 // 4-A. 첫 요청이면 로직 실행 후 결과 캐싱
@@ -85,39 +72,14 @@ class IdempotencyFilter(
         }
     }
 
-    private fun tryAcquireProcessingLock(redisKey: String, requestHash: String): Boolean {
-        val initialData = IdempotencyData(status = STATUS_PROCESSING, requestHash = requestHash)
-        val jsonValue = objectMapper.writeValueAsString(initialData)
-        return redisTemplate.opsForValue().setIfAbsent(redisKey, jsonValue, PROCESSING_TTL) ?: false
-    }
-
     private fun handleExistingRequest(redisKey: String, currentHash: String, response: HttpServletResponse) {
-        val savedJson = redisTemplate.opsForValue().get(redisKey)
-            ?: throw BusinessException(PaymentErrorCode.IDEMPOTENCY_STATE_LOST)
-
-        val savedData = objectMapper.readValue(savedJson, IdempotencyData::class.java)
+        val savedData = idempotencyRedisRepository.get(redisKey)
 
         if (savedData.requestHash != currentHash) {
             throw BusinessException(PaymentErrorCode.IDEMPOTENCY_DATA_MISMATCH)
         }
 
-        when (savedData.status) {
-            STATUS_PROCESSING -> throw BusinessException(PaymentErrorCode.IDEMPOTENCY_PROCESSING)
-            STATUS_DONE -> returnCachedResponse(response, savedData)
-            STATUS_UNKNOWN -> throw BusinessException(PaymentErrorCode.IDEMPOTENCY_RETRY_BLOCKED)
-            else -> throw BusinessException(PaymentErrorCode.IDEMPOTENCY_STATE_LOST)
-        }
-    }
-
-    private fun returnCachedResponse(response: HttpServletResponse, savedData: IdempotencyData) {
-        val status = savedData.responseStatus
-            ?: throw BusinessException(PaymentErrorCode.IDEMPOTENCY_STATE_LOST)
-        val body = savedData.responseBody
-            ?: throw BusinessException(PaymentErrorCode.IDEMPOTENCY_STATE_LOST)
-
-        response.status = status
-        response.contentType = "application/json;charset=UTF-8"
-        response.writer.write(body)
+        savedData.status.handle(savedData, response)
     }
 
     private fun proceedWithFilterChain(
@@ -132,24 +94,11 @@ class IdempotencyFilter(
             filterChain.doFilter(cachedRequest, responseWrapper)
             cacheResponseIfNeeded(responseWrapper, redisKey, currentHash)
         } catch (e: Exception) {
-            markAsUnknown(redisKey, currentHash)
+            idempotencyRedisRepository.saveUnknown(redisKey, currentHash)
             throw e
         } finally {
             responseWrapper.copyBodyToResponse()
         }
-    }
-
-    private fun markAsUnknown(redisKey: String, requestHash: String) {
-        val unknownData = IdempotencyData(
-            status = STATUS_UNKNOWN,
-            requestHash = requestHash
-            // responseStatus/responseBody 없음
-        )
-        redisTemplate.opsForValue().set(
-            redisKey,
-            objectMapper.writeValueAsString(unknownData),
-            UNKNOWN_TTL
-        )
     }
 
     private fun cacheResponseIfNeeded(
@@ -159,27 +108,10 @@ class IdempotencyFilter(
     ) {
         val status = responseWrapper.status
         if (status in 200..499) {
-            val responseBodyStr = String(responseWrapper.contentAsByteArray, Charsets.UTF_8)
-            val completedData = IdempotencyData(
-                status = STATUS_DONE,
-                requestHash = requestHash,
-                responseStatus = status,
-                responseBody = responseBodyStr
-            )
-            redisTemplate.opsForValue().set(redisKey, objectMapper.writeValueAsString(completedData), DONE_TTL)
+            val responseBody = String(responseWrapper.contentAsByteArray, Charsets.UTF_8)
+            idempotencyRedisRepository.saveDone(redisKey, requestHash, status, responseBody)
         } else {
-            markAsUnknown(redisKey, requestHash)
+            idempotencyRedisRepository.saveUnknown(redisKey, requestHash)
         }
-    }
-
-    private fun generateRequestHash(cachedRequest: CachedBodyHttpServletRequestWrapper): String {
-        val bodyBytes = cachedRequest.getCachedBody()
-        val digest = MessageDigest.getInstance("SHA-256")
-        return digest.digest(bodyBytes)
-            .joinToString("") { "%02x".format(it) }
-    }
-
-    private fun buildRedisKey(request: HttpServletRequest, idempotencyKey: String): String {
-        return "$IDEMPOTENCY_PREFIX${request.method}:${request.requestURI}:$idempotencyKey"
     }
 }

--- a/src/main/kotlin/com/pgcore/core/infra/idempotency/IdempotencyFilter.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/idempotency/IdempotencyFilter.kt
@@ -1,0 +1,193 @@
+package com.pgcore.core.infra.idempotency
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.pgcore.core.domain.exception.PaymentErrorCode
+import com.pgcore.core.exception.BusinessException
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import org.springframework.util.AntPathMatcher
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.servlet.HandlerExceptionResolver
+import org.springframework.web.util.ContentCachingResponseWrapper
+import java.security.MessageDigest
+import java.time.Duration
+
+@Component
+class IdempotencyFilter(
+    private val redisTemplate: StringRedisTemplate,
+    private val objectMapper: ObjectMapper,
+    @Qualifier("handlerExceptionResolver") private val exceptionResolver: HandlerExceptionResolver
+) : OncePerRequestFilter() {
+
+    companion object {
+        private const val IDEMPOTENCY_PREFIX = "idempotency:"
+        private const val STATUS_PROCESSING = "PROCESSING"
+        private const val STATUS_UNKNOWN = "UNKNOWN"
+        private const val STATUS_DONE = "DONE"
+        private val PROCESSING_TTL = Duration.ofMinutes(10)
+        private val UNKNOWN_TTL = Duration.ofMinutes(30)
+        private val DONE_TTL = Duration.ofHours(24)
+    }
+
+    private val pathMatcher = AntPathMatcher()
+    private val includePatterns = listOf(
+        "/v1/payments/confirm",
+        "/v1/payments/**/confirm",
+    )
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        // POST만 대상
+        if (!request.method.equals("POST", ignoreCase = true)) return true
+
+        val path = request.requestURI // 컨텍스트패스 있으면 잘라야 할 수도 있음
+        val matched = includePatterns.any { pattern -> pathMatcher.match(pattern, path) }
+
+        // shouldNotFilter는 "필터를 타지 않을지"를 리턴
+        return !matched
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        // 2. Idempotency-Key 헤더 추출 및 검증
+        val idempotencyKey = request.getHeader("Idempotency-Key")
+        if (idempotencyKey.isNullOrBlank()) {
+            exceptionResolver.resolveException(
+                request, response, null,
+                BusinessException(PaymentErrorCode.IDEMPOTENCY_KEY_MISSING)
+            )
+            return
+        }
+
+        val cachedRequest = CachedBodyHttpServletRequestWrapper(request)
+        val requestHash = generateRequestHash(cachedRequest)
+        val redisKey = buildRedisKey(request, idempotencyKey)
+
+        try {
+            // 3. Redis 락 획득 시도 (첫 요청인지 판별)
+            val isFirstRequest = tryAcquireProcessingLock(redisKey, requestHash)
+
+            if (isFirstRequest) {
+                // 4-A. 첫 요청이면 로직 실행 후 결과 캐싱
+                proceedWithFilterChain(cachedRequest, response, filterChain, redisKey, requestHash)
+            } else {
+                // 4-B. 이미 처리 중이거나 완료된 요청이면 캐시 된 결과 반환 (또는 예외 발생)
+                handleExistingRequest(redisKey, requestHash, response)
+            }
+        } catch (e: Exception) {
+            exceptionResolver.resolveException(request, response, null, e)
+        }
+    }
+
+    // =========================================================================
+    // 비즈니스 로직 분리 (Private Methods)
+    // =========================================================================
+
+    private fun tryAcquireProcessingLock(redisKey: String, requestHash: String): Boolean {
+        val initialData = IdempotencyData(status = STATUS_PROCESSING, requestHash = requestHash)
+        val jsonValue = objectMapper.writeValueAsString(initialData)
+        return redisTemplate.opsForValue().setIfAbsent(redisKey, jsonValue, PROCESSING_TTL) ?: false
+    }
+
+    private fun handleExistingRequest(redisKey: String, currentHash: String, response: HttpServletResponse) {
+        val savedJson = redisTemplate.opsForValue().get(redisKey)
+            ?: throw BusinessException(PaymentErrorCode.IDEMPOTENCY_STATE_LOST)
+
+        val savedData = objectMapper.readValue(savedJson, IdempotencyData::class.java)
+
+        if (savedData.requestHash != currentHash) {
+            throw BusinessException(PaymentErrorCode.IDEMPOTENCY_DATA_MISMATCH)
+        }
+
+        when (savedData.status) {
+            STATUS_PROCESSING -> throw BusinessException(PaymentErrorCode.IDEMPOTENCY_PROCESSING)
+            STATUS_DONE -> returnCachedResponse(response, savedData)
+            STATUS_UNKNOWN -> throw BusinessException(PaymentErrorCode.IDEMPOTENCY_RETRY_BLOCKED)
+            else -> throw BusinessException(PaymentErrorCode.IDEMPOTENCY_STATE_LOST)
+        }
+    }
+
+    private fun returnCachedResponse(response: HttpServletResponse, savedData: IdempotencyData) {
+        val status = savedData.responseStatus
+            ?: throw BusinessException(PaymentErrorCode.IDEMPOTENCY_STATE_LOST)
+        val body = savedData.responseBody
+            ?: throw BusinessException(PaymentErrorCode.IDEMPOTENCY_STATE_LOST)
+
+        response.status = status
+        response.contentType = "application/json;charset=UTF-8"
+        response.writer.write(body)
+    }
+
+    private fun proceedWithFilterChain(
+        cachedRequest: CachedBodyHttpServletRequestWrapper,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+        redisKey: String,
+        currentHash: String
+    ) {
+        val responseWrapper = ContentCachingResponseWrapper(response)
+        try {
+            filterChain.doFilter(cachedRequest, responseWrapper)
+            cacheResponseIfNeeded(responseWrapper, redisKey, currentHash)
+        } catch (e: Exception) {
+            markAsUnknown(redisKey, currentHash)
+            throw e
+        } finally {
+            responseWrapper.copyBodyToResponse()
+        }
+    }
+
+    private fun markAsUnknown(redisKey: String, requestHash: String) {
+        val unknownData = IdempotencyData(
+            status = STATUS_UNKNOWN,
+            requestHash = requestHash
+            // responseStatus/responseBody 없음
+        )
+        redisTemplate.opsForValue().set(
+            redisKey,
+            objectMapper.writeValueAsString(unknownData),
+            UNKNOWN_TTL
+        )
+    }
+
+    private fun cacheResponseIfNeeded(
+        responseWrapper: ContentCachingResponseWrapper,
+        redisKey: String,
+        requestHash: String
+    ) {
+        val status = responseWrapper.status
+        if (status in 200..499) {
+            val responseBodyStr = String(responseWrapper.contentAsByteArray, Charsets.UTF_8)
+            val completedData = IdempotencyData(
+                status = STATUS_DONE,
+                requestHash = requestHash,
+                responseStatus = status,
+                responseBody = responseBodyStr
+            )
+            redisTemplate.opsForValue().set(redisKey, objectMapper.writeValueAsString(completedData), DONE_TTL)
+        } else {
+            markAsUnknown(redisKey, requestHash)
+        }
+    }
+
+    // =========================================================================
+    // 유틸리티 메서드
+    // =========================================================================
+
+    private fun generateRequestHash(cachedRequest: CachedBodyHttpServletRequestWrapper): String {
+        val bodyBytes = cachedRequest.getCachedBody()
+        val digest = MessageDigest.getInstance("SHA-256")
+        return digest.digest(bodyBytes)
+            .joinToString("") { "%02x".format(it) }
+    }
+
+    private fun buildRedisKey(request: HttpServletRequest, idempotencyKey: String): String {
+        return "$IDEMPOTENCY_PREFIX${request.method}:${request.requestURI}:$idempotencyKey"
+    }
+}

--- a/src/main/kotlin/com/pgcore/core/infra/idempotency/IdempotencyFilter.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/idempotency/IdempotencyFilter.kt
@@ -85,10 +85,6 @@ class IdempotencyFilter(
         }
     }
 
-    // =========================================================================
-    // 비즈니스 로직 분리 (Private Methods)
-    // =========================================================================
-
     private fun tryAcquireProcessingLock(redisKey: String, requestHash: String): Boolean {
         val initialData = IdempotencyData(status = STATUS_PROCESSING, requestHash = requestHash)
         val jsonValue = objectMapper.writeValueAsString(initialData)
@@ -175,10 +171,6 @@ class IdempotencyFilter(
             markAsUnknown(redisKey, requestHash)
         }
     }
-
-    // =========================================================================
-    // 유틸리티 메서드
-    // =========================================================================
 
     private fun generateRequestHash(cachedRequest: CachedBodyHttpServletRequestWrapper): String {
         val bodyBytes = cachedRequest.getCachedBody()

--- a/src/main/kotlin/com/pgcore/core/infra/idempotency/IdempotencyRedisRepository.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/idempotency/IdempotencyRedisRepository.kt
@@ -1,0 +1,55 @@
+package com.pgcore.core.infra.idempotency
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.pgcore.core.domain.exception.PaymentErrorCode
+import com.pgcore.core.exception.BusinessException
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class IdempotencyRedisRepository(
+    private val redisTemplate: StringRedisTemplate,
+    private val objectMapper: ObjectMapper,
+) {
+    companion object {
+        private const val IDEMPOTENCY_PREFIX = "idempotency:"
+        private val PROCESSING_TTL = Duration.ofMinutes(10)
+        private val UNKNOWN_TTL = Duration.ofMinutes(30)
+        private val DONE_TTL = Duration.ofHours(24)
+    }
+
+    fun buildRedisKey(method: String, requestURI: String, idempotencyKey: String): String {
+        return "$IDEMPOTENCY_PREFIX$method:$requestURI:$idempotencyKey"
+    }
+
+    fun acquireIfAbsent(redisKey: String, requestHash: String): Boolean {
+        val initialData = IdempotencyData(status = IdempotencyStatus.PROCESSING, requestHash = requestHash)
+        return redisTemplate.opsForValue().setIfAbsent(redisKey, serialize(initialData), PROCESSING_TTL) ?: false
+    }
+
+    fun get(redisKey: String): IdempotencyData {
+        val json = redisTemplate.opsForValue().get(redisKey)
+            ?: throw BusinessException(PaymentErrorCode.IDEMPOTENCY_STATE_LOST)
+        return deserialize(json)
+    }
+
+    fun saveUnknown(redisKey: String, requestHash: String) {
+        val data = IdempotencyData(status = IdempotencyStatus.UNKNOWN, requestHash = requestHash)
+        redisTemplate.opsForValue().set(redisKey, serialize(data), UNKNOWN_TTL)
+    }
+
+    fun saveDone(redisKey: String, requestHash: String, responseStatus: Int, responseBody: String) {
+        val data = IdempotencyData(
+            status = IdempotencyStatus.DONE,
+            requestHash = requestHash,
+            responseStatus = responseStatus,
+            responseBody = responseBody,
+        )
+        redisTemplate.opsForValue().set(redisKey, serialize(data), DONE_TTL)
+    }
+
+    private fun serialize(data: IdempotencyData): String = objectMapper.writeValueAsString(data)
+
+    private fun deserialize(json: String): IdempotencyData = objectMapper.readValue(json, IdempotencyData::class.java)
+}

--- a/src/main/kotlin/com/pgcore/core/infra/idempotency/IdempotencyStatus.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/idempotency/IdempotencyStatus.kt
@@ -1,0 +1,32 @@
+package com.pgcore.core.infra.idempotency
+
+import com.pgcore.core.domain.exception.PaymentErrorCode
+import com.pgcore.core.exception.BusinessException
+import jakarta.servlet.http.HttpServletResponse
+
+enum class IdempotencyStatus {
+    PROCESSING {
+        override fun handle(savedData: IdempotencyData, response: HttpServletResponse) {
+            throw BusinessException(PaymentErrorCode.IDEMPOTENCY_PROCESSING)
+        }
+    },
+    DONE {
+        override fun handle(savedData: IdempotencyData, response: HttpServletResponse) {
+            val status = savedData.responseStatus
+                ?: throw BusinessException(PaymentErrorCode.IDEMPOTENCY_STATE_LOST)
+            val body = savedData.responseBody
+                ?: throw BusinessException(PaymentErrorCode.IDEMPOTENCY_STATE_LOST)
+
+            response.status = status
+            response.contentType = "application/json;charset=UTF-8"
+            response.writer.write(body)
+        }
+    },
+    UNKNOWN {
+        override fun handle(savedData: IdempotencyData, response: HttpServletResponse) {
+            throw BusinessException(PaymentErrorCode.IDEMPOTENCY_RETRY_BLOCKED)
+        }
+    };
+
+    abstract fun handle(savedData: IdempotencyData, response: HttpServletResponse)
+}

--- a/src/main/kotlin/com/pgcore/core/infra/repository/PaymentMutationRepositoryImpl.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/repository/PaymentMutationRepositoryImpl.kt
@@ -1,0 +1,26 @@
+package com.pgcore.core.infra.repository
+
+import com.pgcore.core.application.repository.PaymentMutationRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class PaymentMutationRepositoryImpl(
+    private val jpaRepository: SpringDataPaymentMutationJpaRepository
+) : PaymentMutationRepository {
+
+    override fun tryMarkInProgress(paymentKey: String, amount: Long): Int {
+        return jpaRepository.tryMarkInProgress(paymentKey, amount)
+    }
+
+    override fun finalizeApproveSuccess(paymentKey: String): Int {
+        return jpaRepository.finalizeApproveSuccess(paymentKey)
+    }
+
+    override fun finalizeApproveFail(paymentKey: String): Int {
+        return jpaRepository.finalizeApproveFail(paymentKey)
+    }
+
+    override fun markUnknown(paymentKey: String): Int {
+        return jpaRepository.markUnknown(paymentKey)
+    }
+}

--- a/src/main/kotlin/com/pgcore/core/infra/repository/PaymentRepositoryImpl.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/repository/PaymentRepositoryImpl.kt
@@ -14,4 +14,8 @@ class PaymentRepositoryImpl(
 
     override fun findByMerchantIdAndOrderId(merchantId: Long, orderId: String): Payment? =
         jpaRepository.findByMerchantIdAndOrderId(merchantId, orderId)
+
+    override fun findByPaymentKey(paymentKey: String): Payment? {
+        return jpaRepository.findByPaymentKey(paymentKey)
+    }
 }

--- a/src/main/kotlin/com/pgcore/core/infra/repository/PaymentTransactionRepositoryImpl.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/repository/PaymentTransactionRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.pgcore.core.infra.repository
+
+import com.pgcore.core.application.repository.PaymentTransactionRepository
+import com.pgcore.core.domain.payment.PaymentTransaction
+import org.springframework.stereotype.Repository
+
+@Repository
+class PaymentTransactionRepositoryImpl(
+    private val jpaRepository: SpringDataPaymentTransactionJpaRepository
+) : PaymentTransactionRepository {
+
+    override fun saveAndFlush(transaction: PaymentTransaction): PaymentTransaction {
+        return jpaRepository.saveAndFlush(transaction)
+    }
+
+    override fun save(transaction: PaymentTransaction): PaymentTransaction {
+        return jpaRepository.save(transaction)
+    }
+
+    override fun findById(txId: Long): PaymentTransaction? {
+        return jpaRepository.findById(txId).orElse(null)
+    }
+}

--- a/src/main/kotlin/com/pgcore/core/infra/repository/PaymentTransactionRepositoryImpl.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/repository/PaymentTransactionRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.pgcore.core.infra.repository
 
 import com.pgcore.core.application.repository.PaymentTransactionRepository
 import com.pgcore.core.domain.payment.PaymentTransaction
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -18,6 +19,6 @@ class PaymentTransactionRepositoryImpl(
     }
 
     override fun findById(txId: Long): PaymentTransaction? {
-        return jpaRepository.findById(txId).orElse(null)
+        return jpaRepository.findByIdOrNull(txId)
     }
 }

--- a/src/main/kotlin/com/pgcore/core/infra/repository/SpringDataPaymentJpaRepository.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/repository/SpringDataPaymentJpaRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface SpringDataPaymentJpaRepository : JpaRepository<Payment, Long> {
     fun findByMerchantIdAndOrderId(merchantId: Long, orderId: String): Payment?
+    fun findByPaymentKey(paymentKey: String): Payment?
 }

--- a/src/main/kotlin/com/pgcore/core/infra/repository/SpringDataPaymentMutationJpaRepository.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/repository/SpringDataPaymentMutationJpaRepository.kt
@@ -1,0 +1,54 @@
+package com.pgcore.core.infra.repository
+
+import com.pgcore.core.domain.enums.PaymentStatus
+import com.pgcore.core.domain.payment.Payment
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.Repository
+import org.springframework.data.repository.query.Param
+
+interface SpringDataPaymentMutationJpaRepository : Repository<Payment, Long> {
+
+    // CAS(Compare-And-Swap) 방식의 핵심 쿼리: 현재 상태가 READY이고 금액이 정확히 일치할 때만 IN_PROGRESS로 업데이트
+    @Modifying(clearAutomatically = true)
+    @Query("""
+        UPDATE Payment p 
+        SET p.status = :targetStatus, p.updatedAt = CURRENT_TIMESTAMP
+        WHERE p.paymentKey = :paymentKey 
+          AND p.status = :currentStatus 
+          AND p.totalAmount.amount = :amount
+    """)
+    fun tryMarkInProgress(
+        @Param("paymentKey") paymentKey: String,
+        @Param("amount") amount: Long,
+        @Param("currentStatus") currentStatus: PaymentStatus = PaymentStatus.READY,
+        @Param("targetStatus") targetStatus: PaymentStatus = PaymentStatus.IN_PROGRESS
+    ): Int
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+        UPDATE Payment p 
+        SET p.status = 'DONE', p.updatedAt = CURRENT_TIMESTAMP
+        WHERE p.paymentKey = :paymentKey 
+          AND p.status = 'IN_PROGRESS'
+    """)
+    fun finalizeApproveSuccess(@Param("paymentKey") paymentKey: String): Int
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+        UPDATE Payment p 
+        SET p.status = 'ABORTED', p.updatedAt = CURRENT_TIMESTAMP
+        WHERE p.paymentKey = :paymentKey 
+          AND p.status = 'IN_PROGRESS'
+    """)
+    fun finalizeApproveFail(@Param("paymentKey") paymentKey: String): Int
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+        UPDATE Payment p 
+        SET p.status = 'UNKNOWN', p.updatedAt = CURRENT_TIMESTAMP
+        WHERE p.paymentKey = :paymentKey
+          AND p.status = 'IN_PROGRESS'
+    """)
+    fun markUnknown(@Param("paymentKey") paymentKey: String): Int
+}

--- a/src/main/kotlin/com/pgcore/core/infra/repository/SpringDataPaymentTransactionJpaRepository.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/repository/SpringDataPaymentTransactionJpaRepository.kt
@@ -1,0 +1,6 @@
+package com.pgcore.core.infra.repository
+
+import com.pgcore.core.domain.payment.PaymentTransaction
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SpringDataPaymentTransactionJpaRepository : JpaRepository<PaymentTransaction, Long>

--- a/src/main/kotlin/com/pgcore/core/presentation/controller/PaymentApi.kt
+++ b/src/main/kotlin/com/pgcore/core/presentation/controller/PaymentApi.kt
@@ -2,7 +2,11 @@ package com.pgcore.core.presentation.controller
 
 import com.pgcore.core.presentation.controller.dto.ClaimPaymentRequest
 import com.pgcore.core.presentation.controller.dto.ClaimPaymentResponse
+import com.pgcore.core.presentation.controller.dto.ConfirmPaymentRequest
+import com.pgcore.core.presentation.controller.dto.ConfirmPaymentResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.parameters.RequestBody as OasRequestBody
@@ -10,8 +14,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 
 @Tag(name = "Payments", description = "가맹점 결제 API")
 interface PaymentApi {
@@ -41,7 +47,7 @@ interface PaymentApi {
         description = "동일 orderId에 대해 amount 불일치",
         content = [Content()]
     )
-    @PostMapping
+    @PostMapping("/claim")
     fun claim(
         @OasRequestBody(
             required = true,
@@ -50,4 +56,44 @@ interface PaymentApi {
         )
         @RequestBody @Valid request: ClaimPaymentRequest
     ): ResponseEntity<ClaimPaymentResponse>
+
+    @Operation(
+        summary = "결제 승인(CONFIRM)",
+        description = """
+    결제 준비(READY) 상태인 주문에 대해 최종 승인을 요청합니다.
+    
+    - Idempotency-Key를 통해 24시간 동안 중복 승인 요청을 방어합니다.
+    - 외부 PG사와 통신하여 결제를 확정합니다.
+        """,
+        parameters = [
+            Parameter(
+                name = "Idempotency-Key",
+                description = "멱등성 키 (중복 요청 방지용 UUID 등)",
+                required = true,
+                `in` = ParameterIn.HEADER,
+                schema = Schema(type = "string")
+            )
+        ]
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "결제 승인 완료",
+        content = [Content(schema = Schema(implementation = ConfirmPaymentResponse::class))]
+    )
+    @ApiResponse(
+        responseCode = "409",
+        description = "금액 불일치 또는 이미 처리 중인 결제",
+        content = [Content()]
+    )
+    @PostMapping("/{paymentKey}/confirm")
+    fun confirm(
+        @PathVariable paymentKey: String,
+        @RequestHeader("Idempotency-Key") idempotencyKey: String,
+        @OasRequestBody(
+            required = true,
+            description = "결제 승인 요청 본문",
+            content = [Content(schema = Schema(implementation = ConfirmPaymentRequest::class))]
+        )
+        @RequestBody @Valid request: ConfirmPaymentRequest
+    ): ResponseEntity<ConfirmPaymentResponse>
 }

--- a/src/main/kotlin/com/pgcore/core/presentation/controller/PaymentController.kt
+++ b/src/main/kotlin/com/pgcore/core/presentation/controller/PaymentController.kt
@@ -1,8 +1,11 @@
 package com.pgcore.core.presentation.controller
 
 import com.pgcore.core.application.usecase.command.ClaimPaymentUseCase
+import com.pgcore.core.application.usecase.command.ConfirmPaymentUseCase
 import com.pgcore.core.presentation.controller.dto.ClaimPaymentRequest
 import com.pgcore.core.presentation.controller.dto.ClaimPaymentResponse
+import com.pgcore.core.presentation.controller.dto.ConfirmPaymentRequest
+import com.pgcore.core.presentation.controller.dto.ConfirmPaymentResponse
 import com.pgcore.core.presentation.controller.dto.toCommand
 import com.pgcore.core.presentation.controller.dto.toResponse
 import org.springframework.http.HttpStatus
@@ -14,14 +17,25 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/v1/payments")
 class PaymentController(
     private val claimPaymentUseCase: ClaimPaymentUseCase,
+    private val confirmPaymentUseCase: ConfirmPaymentUseCase
 ) : PaymentApi {
 
-    override fun claim(request: ClaimPaymentRequest): ResponseEntity<ClaimPaymentResponse> {
+    override fun claim(
+        request: ClaimPaymentRequest
+    ): ResponseEntity<ClaimPaymentResponse> {
         val result = claimPaymentUseCase.execute(request.toCommand())
-
-        val body = result.toResponse()
         val status = if (result.created) HttpStatus.CREATED else HttpStatus.OK
+        return ResponseEntity.status(status).body(result.toResponse())
+    }
 
-        return ResponseEntity.status(status).body(body)
+    override fun confirm(
+        paymentKey: String,
+        idempotencyKey: String,
+        request: ConfirmPaymentRequest
+    ): ResponseEntity<ConfirmPaymentResponse> {
+        val result = confirmPaymentUseCase.execute(
+            request.toCommand(paymentKey, idempotencyKey)
+        )
+        return ResponseEntity.ok(result.toResponse())
     }
 }

--- a/src/main/kotlin/com/pgcore/core/presentation/controller/dto/ConfirmPaymentRequest.kt
+++ b/src/main/kotlin/com/pgcore/core/presentation/controller/dto/ConfirmPaymentRequest.kt
@@ -1,0 +1,34 @@
+package com.pgcore.core.presentation.controller.dto
+
+import com.pgcore.core.application.usecase.command.dto.ConfirmPaymentCommand
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+data class ConfirmPaymentRequest(
+    @field:NotNull(message = "merchantId는 필수입니다.")
+    val merchantId: Long,
+
+    @field:NotBlank(message = "주문 번호(orderId)는 필수입니다.")
+    val orderId: String,
+
+    @field:Min(value = 1, message = "결제 금액(amount)은 1 이상이어야 합니다.")
+    val amount: Long,
+
+    @field:NotBlank(message = "빌링키(billingKey)는 필수입니다.")
+    val billingKey: String
+)
+
+
+fun ConfirmPaymentRequest.toCommand(
+    paymentKey: String,
+    idempotencyKey: String,
+): ConfirmPaymentCommand =
+    ConfirmPaymentCommand(
+        paymentKey = paymentKey,
+        merchantId = merchantId,
+        idempotencyKey = idempotencyKey,
+        orderId = orderId,
+        amount = amount,
+        billingKey = billingKey,
+    )

--- a/src/main/kotlin/com/pgcore/core/presentation/controller/dto/ConfirmPaymentResponse.kt
+++ b/src/main/kotlin/com/pgcore/core/presentation/controller/dto/ConfirmPaymentResponse.kt
@@ -1,0 +1,19 @@
+package com.pgcore.core.presentation.controller.dto
+
+import com.pgcore.core.application.usecase.command.dto.ConfirmPaymentResult
+import com.pgcore.core.domain.enums.PaymentStatus
+
+data class ConfirmPaymentResponse(
+    val paymentKey: String,
+    val status: PaymentStatus,
+    val amount: Long,
+    val providerTxId: String? // 카드사 승인 번호
+)
+
+fun ConfirmPaymentResult.toResponse(): ConfirmPaymentResponse =
+    ConfirmPaymentResponse(
+        paymentKey = paymentKey,
+        status = status,
+        amount = amount,
+        providerTxId = providerTxId,
+    )


### PR DESCRIPTION
## 💡 PR 개요

가맹점 결제 최종 승인을 처리하는 **결제 승인(Confirm) API**를 구현했습니다.
결제 시스템의 핵심인 멱등성 처리와 동시성 이슈를 방어하며, 외부 PG사(Mock) 연동 시 발생할 수 있는 장애 격리를 위해 트랜잭션을 분리하여 설계했습니다.

## 🛠️ 주요 변경 사항 및 작업 내용

### **1. 결제 승인 API (Presentation Layer)**

- `POST /v1/payments/{paymentKey}/confirm` 엔드포인트 추가
- Swagger(`@Tag`, `@Operation`, `@ApiResponse`)를 통한 API 문서화 및 상세 스펙 정의

### **2. 멱등성 보장 필터 적용 (Infra - Idempotency)**

- `IdempotencyFilter`를 추가하여 헤더의 `Idempotency-Key`와 Redis를 활용한 중복 승인 방어 로직 구현
- `CachedBodyHttpServletRequestWrapper`를 통해 요청 페이로드(Body)의 SHA-256 해시를 떠서, 동일한 멱등키에 다른 데이터가 들어오는 데이터 변조 시도 차단
- 상태별(PROCESSING, DONE, UNKNOWN) TTL 차등 적용 (최대 24시간 캐싱)

### **3. 외부 API 통신과 DB 트랜잭션 분리 (Application Layer)**

- PG사 API 호출 대기로 인한 DB 커넥션 풀 고갈을 막기 위해 트랜잭션을 2단계로 분리 (`@Transactional(propagation = Propagation.REQUIRES_NEW)`)
- **Step 1:** 결제 원장 상태를 `IN_PROGRESS`로 선점하고 트랜잭션 이력을 `PENDING`으로 생성
- **PG 통신:** 외부 카드사(Mock) 승인 API 호출 (Connect 1s, Read 3s 타임아웃 강제 지정)
- **Step 2:** PG 응답 결과에 따라 `DONE` 또는 `ABORTED`로 최종 상태 반영

### **4. CAS(Compare-And-Swap)를 이용한 동시성 제어**

- `SpringDataPaymentMutationJpaRepository`에 커스텀 `@Modifying` 쿼리 추가
- 결제 상태 업데이트 시 기존 상태(`currentStatus`)와 금액을 조건(`WHERE`)으로 걸어, 동시에 여러 요청이 들어와도 단 1건만 업데이트되도록 제어(Lost Update 방지)

### **5. 망취소 및 대사(Reconciliation) 대응 상태 처리**

- 외부 연동 타임아웃 시 안전하게 `UNKNOWN` 상태로 마킹
- PG사는 승인되었으나 시스템 내부 에러로 `ABORTED` 처리될 경우, `needNetCancel = true` 플래그를 켜서 추후 망취소 배치가 처리할 수 있도록 설계

## 🔒 검증 및 테스트

- [x]  (정상) 정상적인 멱등키와 결제 정보로 승인 요청 시 성공(`DONE`) 처리 확인
- [x]  (멱등성) 동일한 멱등키로 동시 다발적 요청 시 1건만 통과하고 나머지는 409 Conflict 또는 캐시 응답 반환 확인
- [x]  (동시성) CAS 쿼리를 통해 이미 처리 중이거나 완료된 결제에 대한 중복 상태 변경 차단 확인
- [x]  (예외) 외부 PG API 타임아웃 발생 시 결제 상태 및 트랜잭션 상태가 `UNKNOWN`으로 마킹되는지 확인
- [x]  (유효성) 결제 원장의 금액(amount)과 요청 금액이 다를 경우 `409 REQUEST_TOTAL_AMOUNT_MISMATCH` 발생 확인

## 📚 참고 사항 (선택)

- **리뷰 포커스:** `ConfirmPaymentUseCase` 내부의 트랜잭션 분리(`step1Writer`, `step2Writer`) 로직과 `IdempotencyFilter`의 락 획득/해제 흐름을 집중적으로 살펴봐 주시면 감사하겠습니다.