### PR TITLE
[Feat/outbox] outbox 구현

### DIFF
--- a/src/main/kotlin/com/pgcore/outbox/application/service/OutboxService.kt
+++ b/src/main/kotlin/com/pgcore/outbox/application/service/OutboxService.kt
@@ -1,0 +1,57 @@
+package com.pgcore.outbox.application.service
+
+import com.pgcore.core.utils.BackoffCalculator
+import com.pgcore.outbox.application.usecase.command.PublishOutboxUseCase
+import com.pgcore.outbox.application.usecase.repository.ClaimedOutboxEvent
+import com.pgcore.outbox.application.usecase.repository.OutboxEventRepository
+import com.pgcore.outbox.util.OutboxMetrics
+import com.pgcore.webhook.application.usecase.command.DispatchWebhookDeliveriesUseCase
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class OutboxService(
+    private val outboxRepo: OutboxEventRepository,
+    private val dispatchWebhookDeliveriesUseCase: DispatchWebhookDeliveriesUseCase,
+    private val metrics: OutboxMetrics,
+) : PublishOutboxUseCase {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        const val ERROR_NO_ACTIVE_ENDPOINT = "NO_ACTIVE_ENDPOINT"
+        const val ERROR_DB_PREFIX = "DB_ERR:"
+    }
+
+    override fun publishBatch(batchSize: Int) {
+        val claimed = outboxRepo.claimDueBatch(batchSize)
+        if (claimed.isEmpty()) return
+
+        log.debug("[OutboxService] claimed {} events", claimed.size)
+        claimed.forEach { processEvent(it) }
+    }
+
+    private fun processEvent(event: ClaimedOutboxEvent) {
+        try {
+            val count = dispatchWebhookDeliveriesUseCase.dispatch(event.eventId, event.merchantId, event.payload)
+
+            if (count == 0) {
+                outboxRepo.markPublished(event.eventId, ERROR_NO_ACTIVE_ENDPOINT)
+                metrics.incrementNoActiveEndpoint()
+                log.info("[OutboxService] eventId={} → NO_ACTIVE_ENDPOINT (PUBLISHED)", event.eventId)
+            } else {
+                log.debug("[OutboxService] eventId={} → PUBLISHED ({}개 endpoints)", event.eventId, count)
+            }
+        } catch (e: Exception) {
+            val nextRetry = event.retryCount + 1
+            val nextAt = BackoffCalculator.nextAttemptAt(nextRetry)
+            val errSummary = "$ERROR_DB_PREFIX${e.javaClass.simpleName}".take(512)
+            log.error("[OutboxService] eventId={} deliveries 생성 실패 → FAILED: {}", event.eventId, errSummary)
+            try {
+                outboxRepo.markFailed(event.eventId, nextRetry, nextAt, errSummary)
+            } catch (ex: Exception) {
+                log.error("[OutboxService] eventId={} markFailed도 실패 (lease sweeper가 복구 예정)", event.eventId, ex)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/pgcore/outbox/application/usecase/command/PublishOutboxUseCase.kt
+++ b/src/main/kotlin/com/pgcore/outbox/application/usecase/command/PublishOutboxUseCase.kt
@@ -1,0 +1,5 @@
+package com.pgcore.outbox.application.usecase.command
+
+interface PublishOutboxUseCase {
+    fun publishBatch(batchSize: Int)
+}

--- a/src/main/kotlin/com/pgcore/outbox/application/usecase/repository/ClaimedOutboxEvent.kt
+++ b/src/main/kotlin/com/pgcore/outbox/application/usecase/repository/ClaimedOutboxEvent.kt
@@ -1,0 +1,10 @@
+package com.pgcore.outbox.application.usecase.repository
+
+data class ClaimedOutboxEvent(
+    val eventId: Long,
+    val merchantId: Long,
+    val aggregateId: String,
+    val eventType: String,
+    val payload: String,
+    val retryCount: Int,
+)

--- a/src/main/kotlin/com/pgcore/outbox/application/usecase/repository/OutboxEventRepository.kt
+++ b/src/main/kotlin/com/pgcore/outbox/application/usecase/repository/OutboxEventRepository.kt
@@ -1,0 +1,10 @@
+package com.pgcore.outbox.application.usecase.repository
+
+import java.time.LocalDateTime
+
+interface OutboxEventRepository {
+    fun claimDueBatch(batchSize: Int): List<ClaimedOutboxEvent>
+    fun markPublished(eventId: Long, lastError: String?)
+    fun markFailed(eventId: Long, nextRetry: Int, nextAt: LocalDateTime, error: String)
+    fun recoverExpiredLeases(leaseMinutes: Int): Int
+}

--- a/src/main/kotlin/com/pgcore/outbox/domain/OutboxEvent.kt
+++ b/src/main/kotlin/com/pgcore/outbox/domain/OutboxEvent.kt
@@ -1,0 +1,100 @@
+package com.pgcore.outbox.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "outbox_events",
+    indexes = [
+        Index(name = "idx_outbox_status_next", columnList = "status, next_attempt_at"),
+        Index(name = "idx_outbox_merchant_created", columnList = "merchant_id, created_at"),
+    ]
+)
+class OutboxEvent protected constructor(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val eventId: Long = 0,
+
+    @Column(nullable = false, updatable = false)
+    val merchantId: Long,
+
+    @Column(length = 128, nullable = false, updatable = false)
+    val aggregateId: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 64, nullable = false, updatable = false)
+    val eventType: OutboxEventType,
+
+    @Column(columnDefinition = "JSON", nullable = false, updatable = false)
+    val payload: String,
+
+    status: OutboxStatus = OutboxStatus.READY,
+    retryCount: Int = 0,
+    nextAttemptAt: LocalDateTime = LocalDateTime.now(),
+    lastError: String? = null,
+
+    @Column(nullable = false, updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+) {
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    var status: OutboxStatus = status
+        protected set
+
+    @Column(nullable = false)
+    var retryCount: Int = retryCount
+        protected set
+
+    @Column(nullable = false)
+    var nextAttemptAt: LocalDateTime = nextAttemptAt
+        protected set
+
+    @Column(length = 512)
+    var lastError: String? = lastError
+        protected set
+
+    @Column(nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+        protected set
+
+    companion object {
+        fun create(
+            merchantId: Long,
+            aggregateId: String,
+            eventType: OutboxEventType,
+            payload: String,
+        ): OutboxEvent = OutboxEvent(
+            merchantId = merchantId,
+            aggregateId = aggregateId,
+            eventType = eventType,
+            payload = payload,
+        )
+    }
+
+    fun markPublished(lastError: String? = null) {
+        status = OutboxStatus.PUBLISHED
+        this.lastError = lastError
+        updateOutbox()
+    }
+
+    fun markFailed(error: String, backoffAt: LocalDateTime) {
+        status = OutboxStatus.FAILED
+        retryCount++
+        nextAttemptAt = backoffAt
+        lastError = error
+        updateOutbox()
+    }
+
+    private fun updateOutbox() {
+        updatedAt = LocalDateTime.now()
+    }
+}

--- a/src/main/kotlin/com/pgcore/outbox/domain/OutboxEventType.kt
+++ b/src/main/kotlin/com/pgcore/outbox/domain/OutboxEventType.kt
@@ -1,0 +1,8 @@
+package com.pgcore.outbox.domain
+
+enum class OutboxEventType {
+    PAYMENT_DONE,
+    PAYMENT_CANCELED,
+    PAYMENT_FAILED,
+    PAYMENT_EXPIRED,
+}

--- a/src/main/kotlin/com/pgcore/outbox/domain/OutboxStatus.kt
+++ b/src/main/kotlin/com/pgcore/outbox/domain/OutboxStatus.kt
@@ -1,0 +1,15 @@
+package com.pgcore.outbox.domain
+
+/**
+ * READY        - 처리 대기
+ * IN_PROGRESS  - 워커가 claim, deliveries 생성 진행 중
+ * PUBLISHED    - webhook_deliveries 생성 완료 (전송 성공과 무관)
+ * FAILED       - deliveries 생성 단계 실패 (DB 오류 등). 재시도 대상.
+ */
+enum class OutboxStatus {
+    READY,
+    IN_PROGRESS,
+    PUBLISHED,
+    FAILED,
+    ;
+}

--- a/src/main/kotlin/com/pgcore/outbox/infra/persistence/OutboxEventRepositoryImpl.kt
+++ b/src/main/kotlin/com/pgcore/outbox/infra/persistence/OutboxEventRepositoryImpl.kt
@@ -1,0 +1,120 @@
+package com.pgcore.outbox.infra.persistence
+
+import com.pgcore.outbox.application.usecase.repository.ClaimedOutboxEvent
+import com.pgcore.outbox.application.usecase.repository.OutboxEventRepository
+import com.pgcore.outbox.domain.OutboxStatus
+import com.pgcore.outbox.domain.QOutboxEvent
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.LockModeType
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+// outbox_events claim/mutation QueryDSL 리포지토리
+@Repository
+class OutboxEventRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : OutboxEventRepository {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val qEvent = QOutboxEvent.outboxEvent
+
+    companion object {
+        private const val JPA_LOCK_TIMEOUT_HINT = "jakarta.persistence.lock.timeout"
+        private const val SKIP_LOCKED = -2
+        private const val ERROR_LEASE_EXPIRED = "LEASE_EXPIRED"
+    }
+
+    // TX1 (REQUIRES_NEW): due 이벤트 batch claim 후 IN_PROGRESS로 전이
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    override fun claimDueBatch(batchSize: Int): List<ClaimedOutboxEvent> {
+        val now = LocalDateTime.now()
+
+        val rows = queryFactory
+            .selectFrom(qEvent)
+            .where(
+                qEvent.status.`in`(OutboxStatus.READY, OutboxStatus.FAILED),
+                qEvent.nextAttemptAt.loe(now),
+            )
+            .orderBy(qEvent.nextAttemptAt.asc(), qEvent.eventId.asc())
+            .limit(batchSize.toLong())
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+            .setHint(JPA_LOCK_TIMEOUT_HINT, SKIP_LOCKED)
+            .fetch()
+
+        if (rows.isEmpty()) return emptyList()
+
+        val ids = rows.map { it.eventId }
+        val updated = queryFactory.update(qEvent)
+            .set(qEvent.status, OutboxStatus.IN_PROGRESS)
+            .set(qEvent.updatedAt, LocalDateTime.now())
+            .where(
+                qEvent.eventId.`in`(ids),
+                qEvent.status.`in`(OutboxStatus.READY, OutboxStatus.FAILED),
+            )
+            .execute()
+
+        if (updated < rows.size) {
+            log.warn("[OutboxClaim] expected={} updated={}: 일부 row가 sweeper에 의해 선점됨", rows.size, updated)
+        }
+
+        return rows.map {
+            ClaimedOutboxEvent(
+                eventId = it.eventId,
+                merchantId = it.merchantId,
+                aggregateId = it.aggregateId,
+                eventType = it.eventType.name,
+                payload = it.payload,
+                retryCount = it.retryCount,
+            )
+        }
+    }
+
+    // TX2에 합류: eventId를 PUBLISHED로 전이, last_error는 항상 갱신
+    @Transactional(propagation = Propagation.REQUIRED)
+    override fun markPublished(eventId: Long, lastError: String?) {
+        val clause = queryFactory.update(qEvent)
+            .set(qEvent.status, OutboxStatus.PUBLISHED)
+            .set(qEvent.updatedAt, LocalDateTime.now())
+
+        lastError
+            ?.takeUnless { it.isBlank() }
+            ?.let {
+            clause.set(qEvent.lastError, it)
+        } ?: clause.setNull(qEvent.lastError)
+
+        clause.where(qEvent.eventId.eq(eventId)).execute()
+    }
+
+    // TX3 (REQUIRES_NEW): eventId를 FAILED로 전이하고 backoff 시간 설정
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    override fun markFailed(eventId: Long, nextRetry: Int, nextAt: LocalDateTime, error: String) {
+        queryFactory.update(qEvent)
+            .set(qEvent.status, OutboxStatus.FAILED)
+            .set(qEvent.retryCount, nextRetry)
+            .set(qEvent.nextAttemptAt, nextAt)
+            .set(qEvent.lastError, error)
+            .set(qEvent.updatedAt, LocalDateTime.now())
+            .where(qEvent.eventId.eq(eventId))
+            .execute()
+    }
+
+    // REQUIRES_NEW: lease 만료된 IN_PROGRESS 이벤트를 FAILED로 복구
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    override fun recoverExpiredLeases(leaseMinutes: Int): Int {
+        val threshold = LocalDateTime.now().minusMinutes(leaseMinutes.toLong())
+        return queryFactory.update(qEvent)
+            .set(qEvent.status, OutboxStatus.FAILED)
+            .set(qEvent.nextAttemptAt, LocalDateTime.now())
+            .set(qEvent.lastError, ERROR_LEASE_EXPIRED)
+            .set(qEvent.updatedAt, LocalDateTime.now())
+            .where(
+                qEvent.status.eq(OutboxStatus.IN_PROGRESS),
+                qEvent.updatedAt.lt(threshold),
+            )
+            .execute()
+            .toInt()
+    }
+}

--- a/src/main/kotlin/com/pgcore/outbox/util/OutboxDispatchScheduler.kt
+++ b/src/main/kotlin/com/pgcore/outbox/util/OutboxDispatchScheduler.kt
@@ -1,0 +1,24 @@
+package com.pgcore.outbox.util
+
+import com.pgcore.outbox.application.usecase.command.PublishOutboxUseCase
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class OutboxDispatchScheduler(
+    private val publishOutboxUseCase: PublishOutboxUseCase,
+    @Value("\${webhook.dispatcher.batch-size:50}") private val batchSize: Int,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(fixedDelayString = "\${webhook.dispatcher.interval-ms:500}")
+    fun dispatch() {
+        try {
+            publishOutboxUseCase.publishBatch(batchSize)
+        } catch (e: Exception) {
+            log.error("[OutboxDispatchScheduler] dispatch 루프 예외", e)
+        }
+    }
+}

--- a/src/main/kotlin/com/pgcore/outbox/util/OutboxLeaseSweeper.kt
+++ b/src/main/kotlin/com/pgcore/outbox/util/OutboxLeaseSweeper.kt
@@ -1,0 +1,31 @@
+package com.pgcore.outbox.util
+
+import com.pgcore.outbox.application.usecase.repository.OutboxEventRepository
+import com.pgcore.outbox.util.OutboxMetrics
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+// IN_PROGRESS 상태로 lease 시간 이상 멈춰있는 outbox 이벤트를 FAILED로 복구하는 스케줄러
+@Component
+class OutboxLeaseSweeper(
+    private val outboxRepo: OutboxEventRepository,
+    private val metrics: OutboxMetrics,
+    @Value("\${webhook.lease.minutes:3}") private val leaseMinutes: Int,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(fixedDelayString = "\${webhook.lease.sweep-interval-ms:30000}")
+    fun sweep() {
+        try {
+            val recovered = outboxRepo.recoverExpiredLeases(leaseMinutes)
+            if (recovered > 0) {
+                log.warn("[OutboxLeaseSweeper] lease 만료 복구: {}건 (lease={}분)", recovered, leaseMinutes)
+                metrics.incrementOutboxLeaseRecovered(recovered)
+            }
+        } catch (e: Exception) {
+            log.error("[OutboxLeaseSweeper] sweep 실패", e)
+        }
+    }
+}

--- a/src/main/kotlin/com/pgcore/outbox/util/OutboxMetrics.kt
+++ b/src/main/kotlin/com/pgcore/outbox/util/OutboxMetrics.kt
@@ -1,0 +1,27 @@
+package com.pgcore.outbox.util
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.stereotype.Component
+
+// Outbox BC 관측 메트릭 (no_active_endpoint, lease_recovered)
+@Component
+class OutboxMetrics(private val registry: MeterRegistry) {
+
+    private val outboxNoActiveEndpoint: Counter = Counter.builder(METRIC_NO_ACTIVE_ENDPOINT)
+        .description("outbox events published with NO_ACTIVE_ENDPOINT")
+        .register(registry)
+
+    private val outboxLeaseRecovered: Counter = Counter.builder(METRIC_LEASE_RECOVERED)
+        .description("outbox events recovered from stuck IN_PROGRESS by lease sweeper")
+        .register(registry)
+
+    fun incrementNoActiveEndpoint() = outboxNoActiveEndpoint.increment()
+
+    fun incrementOutboxLeaseRecovered(count: Int) = outboxLeaseRecovered.increment(count.toDouble())
+
+    companion object {
+        private const val METRIC_NO_ACTIVE_ENDPOINT = "webhook.outbox.no_active_endpoint"
+        private const val METRIC_LEASE_RECOVERED = "webhook.outbox.lease_recovered"
+    }
+}

--- a/src/main/kotlin/com/pgcore/webhook/application/service/WebhookDeliveryService.kt
+++ b/src/main/kotlin/com/pgcore/webhook/application/service/WebhookDeliveryService.kt
@@ -1,6 +1,7 @@
 package com.pgcore.webhook.application.service
 
 import com.pgcore.core.utils.BackoffCalculator
+import com.pgcore.outbox.application.usecase.repository.OutboxEventRepository
 import com.pgcore.webhook.application.EndpointConcurrencyLimiter
 import com.pgcore.webhook.application.service.dto.EndpointKey
 import com.pgcore.webhook.application.usecase.command.DispatchWebhookDeliveriesUseCase
@@ -27,6 +28,7 @@ import java.util.concurrent.Executors
 class WebhookDeliveryService(
     private val deliveryRepository: WebhookDeliveryRepository,
     private val endpointRepository: WebhookEndpointRepository,
+    private val outboxRepository: OutboxEventRepository,
     private val sendClient: WebhookSendClient,
     private val metrics: WebhookMetrics,
     private val secretEncryptor: SecretEncryptor,
@@ -66,6 +68,7 @@ class WebhookDeliveryService(
             endpointIds = activeEndpoints.map { it.endpointId },
             payloadSnapshot = payload,
         )
+        outboxRepository.markPublished(eventId, null)
         return activeEndpoints.size
     }
 

--- a/src/test/kotlin/com/pgcore/webhook/integration/OutboxDispatcherIntegrationTest.kt
+++ b/src/test/kotlin/com/pgcore/webhook/integration/OutboxDispatcherIntegrationTest.kt
@@ -1,0 +1,167 @@
+package com.pgcore.webhook.integration
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.pgcore.outbox.application.service.OutboxService
+import com.pgcore.outbox.util.OutboxDispatchScheduler
+import com.pgcore.outbox.util.OutboxLeaseSweeper
+import com.pgcore.webhook.application.usecase.repository.WebhookDeliveryRepository
+import com.pgcore.webhook.util.DeliveryLeaseSweeper
+import com.pgcore.webhook.util.WebhookDeliveryWorker
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import java.sql.Timestamp
+import java.time.LocalDateTime
+
+// OutboxDispatchScheduler 통합 테스트: outbox→delivery 생성 플로우, UNIQUE 멱등성, endpoint 없는 경우
+// 스케줄러 빈을 MockkBean으로 등록해 테스트 중 자동 실행 방지 (dispatcher만 직접 호출)
+@SpringBootTest
+@ActiveProfiles("test")
+class OutboxDispatcherIntegrationTest {
+
+    @MockkBean lateinit var outboxLeaseSweeper: OutboxLeaseSweeper
+    @MockkBean lateinit var deliveryLeaseSweeper: DeliveryLeaseSweeper
+    @MockkBean lateinit var webhookDeliveryWorker: WebhookDeliveryWorker
+
+    private val objectMapper = ObjectMapper()
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    lateinit var deliveryRepo: WebhookDeliveryRepository
+
+    @Autowired
+    lateinit var dispatcher: OutboxDispatchScheduler
+
+    @BeforeEach
+    fun setUp() {
+        jdbcTemplate.execute("DELETE FROM webhook_deliveries")
+        jdbcTemplate.execute("DELETE FROM outbox_events")
+        jdbcTemplate.execute("DELETE FROM merchant_webhook_endpoints")
+    }
+
+    @Test
+    fun `outbox 1개 + endpoint 2개 → delivery 2개 생성되고 outbox는 PUBLISHED`() {
+        val payload = """{"eventType":"PAYMENT_DONE","paymentKey":"pk_001"}"""
+        val dueAt = Timestamp.valueOf(LocalDateTime.now().minusSeconds(1))
+        jdbcTemplate.update(
+            """INSERT INTO outbox_events (merchant_id, aggregate_id, event_type, payload, status, retry_count, next_attempt_at, created_at, updated_at)
+               VALUES (100, 'pk_001', 'PAYMENT_DONE', ?, 'READY', 0, ?, NOW(), NOW())""",
+            payload, dueAt
+        )
+        val eventId = jdbcTemplate.queryForObject("SELECT MAX(event_id) FROM outbox_events", Long::class.java)!!
+
+        jdbcTemplate.update(
+            "INSERT INTO merchant_webhook_endpoints (merchant_id, url, secret, is_active, created_at, updated_at) VALUES (100, 'https://ep1.example.com/hook', 'secret1', true, NOW(), NOW())"
+        )
+        jdbcTemplate.update(
+            "INSERT INTO merchant_webhook_endpoints (merchant_id, url, secret, is_active, created_at, updated_at) VALUES (100, 'https://ep2.example.com/hook', 'secret2', true, NOW(), NOW())"
+        )
+
+        dispatcher.dispatch()
+
+        val deliveryCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM webhook_deliveries WHERE event_id = ?",
+            Long::class.java, eventId
+        )
+        assertEquals(2L, deliveryCount, "delivery가 2개 생성되어야 합니다.")
+
+        val snapshots = jdbcTemplate.queryForList(
+            "SELECT payload_snapshot FROM webhook_deliveries WHERE event_id = ?",
+            String::class.java, eventId
+        )
+        val expectedJson = parseJson(payload)
+        snapshots.forEach { snapshot ->
+            assertEquals(expectedJson, parseJson(snapshot), "payload_snapshot이 원본 payload와 동일해야 합니다.")
+        }
+
+        val outboxStatus = jdbcTemplate.queryForObject(
+            "SELECT status FROM outbox_events WHERE event_id = ?",
+            String::class.java, eventId
+        )
+        assertEquals("PUBLISHED", outboxStatus, "outbox가 PUBLISHED 상태여야 합니다.")
+
+        val lastError = jdbcTemplate.queryForObject(
+            "SELECT last_error FROM outbox_events WHERE event_id = ?",
+            String::class.java, eventId
+        )
+        assertEquals(null, lastError, "endpoint 있을 때 last_error는 NULL이어야 합니다.")
+    }
+
+    @Test
+    @Transactional
+    fun `동일 event_id + endpoint_id 중복 insert는 UNIQUE 제약으로 1개만 유지`() {
+        val payload = """{"eventType":"PAYMENT_DONE","paymentKey":"pk_dup"}"""
+        val dueAt = Timestamp.valueOf(LocalDateTime.now().minusSeconds(1))
+        jdbcTemplate.update(
+            """INSERT INTO outbox_events (merchant_id, aggregate_id, event_type, payload, status, retry_count, next_attempt_at, created_at, updated_at)
+               VALUES (100, 'pk_dup', 'PAYMENT_DONE', ?, 'PUBLISHED', 0, ?, NOW(), NOW())""",
+            payload, dueAt
+        )
+        val eventId = jdbcTemplate.queryForObject("SELECT MAX(event_id) FROM outbox_events", Long::class.java)!!
+
+        jdbcTemplate.update(
+            "INSERT INTO merchant_webhook_endpoints (merchant_id, url, secret, is_active, created_at, updated_at) VALUES (100, 'https://dup.example.com/hook', 'secret', true, NOW(), NOW())"
+        )
+        val endpointId = jdbcTemplate.queryForObject("SELECT MAX(endpoint_id) FROM merchant_webhook_endpoints", Long::class.java)!!
+
+        deliveryRepo.bulkInsertIgnore(eventId, 100L, listOf(endpointId), payload)
+        deliveryRepo.bulkInsertIgnore(eventId, 100L, listOf(endpointId), payload)
+
+        val count = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM webhook_deliveries WHERE event_id = ? AND endpoint_id = ?",
+            Long::class.java, eventId, endpointId
+        )
+        assertEquals(1L, count, "UNIQUE 제약으로 중복 insert는 1개만 남아야 합니다.")
+    }
+
+    @Test
+    fun `endpoint 0개이면 outbox는 PUBLISHED이고 last_error=NO_ACTIVE_ENDPOINT`() {
+        val payload = """{"eventType":"PAYMENT_CANCELED","paymentKey":"pk_no_ep"}"""
+        val dueAt = Timestamp.valueOf(LocalDateTime.now().minusSeconds(1))
+        jdbcTemplate.update(
+            """INSERT INTO outbox_events (merchant_id, aggregate_id, event_type, payload, status, retry_count, next_attempt_at, created_at, updated_at)
+               VALUES (999, 'pk_no_ep', 'PAYMENT_CANCELED', ?, 'READY', 0, ?, NOW(), NOW())""",
+            payload, dueAt
+        )
+        val eventId = jdbcTemplate.queryForObject("SELECT MAX(event_id) FROM outbox_events", Long::class.java)!!
+
+        dispatcher.dispatch()
+
+        val outboxStatus = jdbcTemplate.queryForObject(
+            "SELECT status FROM outbox_events WHERE event_id = ?",
+            String::class.java, eventId
+        )
+        assertEquals("PUBLISHED", outboxStatus, "endpoint 없어도 PUBLISHED여야 합니다.")
+
+        val lastError = jdbcTemplate.queryForObject(
+            "SELECT last_error FROM outbox_events WHERE event_id = ?",
+            String::class.java, eventId
+        )
+        assertEquals(OutboxService.ERROR_NO_ACTIVE_ENDPOINT, lastError, "last_error가 NO_ACTIVE_ENDPOINT여야 합니다.")
+
+        val deliveryCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM webhook_deliveries WHERE event_id = ?",
+            Long::class.java, eventId
+        )
+        assertEquals(0L, deliveryCount, "endpoint 없으면 delivery가 없어야 합니다.")
+    }
+
+    private fun parseJson(raw: String): JsonNode {
+        var node = objectMapper.readTree(raw)
+        var guard = 0
+        while (node.isTextual && guard < 5) {
+            node = objectMapper.readTree(node.asText())
+            guard++
+        }
+        return node
+    }
+}


### PR DESCRIPTION
변경 사항
- Outbox 이벤트 발행 흐름을 `READY → IN_PROGRESS → PUBLISHED/FAILED` 상태 전이로 정리.
- `SKIP LOCKED` 기반 claim 처리로 멀티 인스턴스 환경에서 중복 처리 가능성을 낮췄습니다.
- dispatch 실패 시 backoff 재시도(`retry_count`, `next_attempt_at`)를 적용하고, stuck `IN_PROGRESS`는 lease sweeper로 `FAILED` 복구되도록 구현
- `webhook.outbox.no_active_endpoint`, `webhook.outbox.lease_recovered` 메트릭을 추가해 운영 관측성을 보강
