### PR TITLE
[FEAT] 취소 관련 대사 기능 구현

### DIFF
--- a/src/main/kotlin/com/pgcore/core/application/port/out/dto/CardCancelResult.kt
+++ b/src/main/kotlin/com/pgcore/core/application/port/out/dto/CardCancelResult.kt
@@ -5,6 +5,7 @@ package com.pgcore.core.application.port.out.dto
  */
 data class CardCancelResult(
     val status: CardProviderResponseStatus,
+    val providerTxId: String?,
     val canceledAmount: Long?,
     val remainingAmount: Long?,
     val failureCode: String?

--- a/src/main/kotlin/com/pgcore/core/application/repository/PaymentMutationRepository.kt
+++ b/src/main/kotlin/com/pgcore/core/application/repository/PaymentMutationRepository.kt
@@ -13,6 +13,12 @@ interface PaymentMutationRepository {
     // 4. 통신 타임아웃/장애 시 불명 상태 마킹 (-> UNKNOWN)
     fun markUnknown(paymentKey: String): Int
 
+    // 4-1. 대사 확정: UNKNOWN/IN_PROGRESS -> DONE
+    fun reconcileApproveSuccess(paymentKey: String): Int
+
+    // 4-2. 대사 확정: UNKNOWN/IN_PROGRESS -> ABORTED
+    fun reconcileApproveFail(paymentKey: String): Int
+
     // 5. 부분/전체 취소 적용 결과 반환
     fun applyCancel(paymentKey: String, cancelAmount: Long): CancelApplyResult
 }
@@ -20,5 +26,9 @@ interface PaymentMutationRepository {
 enum class CancelApplyResult {
     FULL_CANCELED,
     PARTIAL_CANCELED,
-    NOOP,
+    NOOP;
+
+    fun isFullCancel() = this == PARTIAL_CANCELED
+    fun isPartialCancel() = this == PARTIAL_CANCELED
+    fun isNoneCancel() = this == NOOP
 }

--- a/src/main/kotlin/com/pgcore/core/application/repository/PaymentMutationRepository.kt
+++ b/src/main/kotlin/com/pgcore/core/application/repository/PaymentMutationRepository.kt
@@ -28,7 +28,7 @@ enum class CancelApplyResult {
     PARTIAL_CANCELED,
     NOOP;
 
-    fun isFullCancel() = this == PARTIAL_CANCELED
+    fun isFullCancel() = this == FULL_CANCELED
     fun isPartialCancel() = this == PARTIAL_CANCELED
     fun isNoneCancel() = this == NOOP
 }

--- a/src/main/kotlin/com/pgcore/core/application/repository/PaymentTransactionRepository.kt
+++ b/src/main/kotlin/com/pgcore/core/application/repository/PaymentTransactionRepository.kt
@@ -19,11 +19,13 @@ interface PaymentTransactionRepository {
     fun existsSuccessCancelTx(paymentId: Long, amount: Long, idempotencyKey: String): Boolean
 
     /**
-     * needNetCancel == true 이고 nextAttemptAt 이 now 이전(또는 null)인 트랜잭션을 조회합니다.
-     * 배치가 주기적으로 호출하여 망취소 대상 건을 가져옵니다.
-     *
      * @param now       현재 시각 기준 (nextAttemptAt <= now 인 건만 포함)
      * @param limit     한 번에 처리할 최대 건수 (기본값 100)
      */
     fun findPendingNetCancels(now: LocalDateTime, limit: Int = 100): List<PaymentTransaction>
+
+    /**
+     * @param limit     한 번에 처리할 최대 건수 (기본값 100)
+     */
+    fun findPendingReconciliations(limit: Int = 100): List<PaymentTransaction>
 }

--- a/src/main/kotlin/com/pgcore/core/application/service/PaymentService.kt
+++ b/src/main/kotlin/com/pgcore/core/application/service/PaymentService.kt
@@ -165,6 +165,7 @@ class PaymentService(
         // 3) Step 1: 상태 변경 없이 PENDING 이력 생성 (TX-1)
         val txId = cancelStep1Writer.createCancelTx(command, payment.paymentId)
         var cancelStatus: CardProviderResponseStatus? = null
+        var providerTxId: String? = null
 
         try {
             // 4) 외부 API 통신 (TX 밖)
@@ -176,6 +177,7 @@ class PaymentService(
             )
 
             cancelStatus = providerResponse.status
+            providerTxId = providerResponse.providerTxId
 
             // 5) Step 2: 결과 반영 (TX-2)
             val transaction = cancelStep2Writer.finalizeCancel(
@@ -184,8 +186,8 @@ class PaymentService(
                 cancelStatus = providerResponse
             )
 
-            if (transaction.needNetCancel) {
-                // PG사 승인 성공했으나 DB 반영 실패 -> 망취소(대사) 대상 마킹
+            if (transaction.needReconciliation) {
+                // 카드사 취소는 성공했으나 로컬 원장 반영 실패 → 대사 배치 보정 대상
                 throw BusinessException(PaymentErrorCode.PAYMENT_STATE_MISMATCH)
             }
 
@@ -200,11 +202,11 @@ class PaymentService(
                 balanceAmount = updatedPayment.balanceAmount.amount,
             )
         } catch (e: Exception) {
-            runCatching {
-                cancelStep2Writer.handleExceptionAndMarkUnknown(
+            runCatching<Unit> {
+                cancelStep2Writer.markReconciliationOrUnknownOnException(
                     txId = txId,
                     cancelStatus = cancelStatus,
-                    providerTxId = null
+                    providerTxId = providerTxId
                 )
             }
             throw e

--- a/src/main/kotlin/com/pgcore/core/application/usecase/batch/ReconcileCancelService.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/batch/ReconcileCancelService.kt
@@ -1,0 +1,117 @@
+package com.pgcore.core.application.usecase.batch
+
+import com.pgcore.core.application.repository.PaymentMutationRepository
+import com.pgcore.core.application.repository.PaymentTransactionRepository
+import com.pgcore.core.application.usecase.batch.dto.ReconcileCancelCommand
+import com.pgcore.core.application.usecase.batch.dto.ReconcileCancelResult
+import com.pgcore.core.domain.exception.PaymentErrorCode
+import com.pgcore.core.domain.payment.PaymentTransaction
+import com.pgcore.core.domain.payment.PaymentTxStatus
+import com.pgcore.core.exception.BusinessException
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 대사(Reconciliation) 보정 서비스
+ *
+ * 처리 흐름:
+ *  1. 멱등성 검사: 이미 보정 완료된 건이면 ALREADY_RESOLVED 반환
+ *  2. Payment 원장 강제 차감: applyCancel (카드사는 이미 취소 완료 → 무조건 반영)
+ *  3. PaymentTransaction 상태 보정: markReconciliationDone → SUCCESS
+ */
+@Service
+class ReconcileCancelService(
+    private val paymentTransactionRepository: PaymentTransactionRepository,
+    private val paymentMutationRepository: PaymentMutationRepository,
+) : ReconcileCancelUseCase {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    override fun execute(command: ReconcileCancelCommand): ReconcileCancelResult {
+        val transaction = loadAndValidateReconciliationTarget(command.txId)
+            ?: return alreadyResolvedResult(command)
+
+        return try {
+            forciblyApplyCancelToPaymentLedger(command)
+            markTransactionAsReconciled(transaction)
+
+            log.info(
+                "[ReconcileCancel] 대사 보정 완료. txId={}, paymentKey={}, amount={}, providerTxId={}",
+                command.txId, command.paymentKey, command.amount, command.providerTxId,
+            )
+
+            ReconcileCancelResult(
+                txId = command.txId,
+                paymentKey = command.paymentKey,
+                outcome = ReconcileCancelResult.Outcome.SUCCESS,
+            )
+        } catch (e: Exception) {
+            log.error(
+                "[ReconcileCancel] 보정 처리 중 오류 발생. txId={}, paymentKey={}, error={}",
+                command.txId, command.paymentKey, e.message, e,
+            )
+            ReconcileCancelResult(
+                txId = command.txId,
+                paymentKey = command.paymentKey,
+                outcome = ReconcileCancelResult.Outcome.ERROR,
+                message = e.message,
+            )
+        }
+    }
+
+    /**
+     * TX를 조회하고 대사 보정 대상인지 검증합니다.
+     * 이미 보정이 완료된 건(needReconciliation=false)이면 null을 반환합니다.
+     */
+    private fun loadAndValidateReconciliationTarget(txId: Long): PaymentTransaction? {
+        val transaction = paymentTransactionRepository.findById(txId)
+            ?: throw BusinessException(PaymentErrorCode.PAYMENT_TX_NOT_FOUND)
+
+        if (!transaction.needReconciliation) {
+            log.info("[ReconcileCancel] txId={} 이미 보정 완료된 건입니다. 처리를 건너뜁니다.", txId)
+            return null
+        }
+
+        if (transaction.status != PaymentTxStatus.UNKNOWN) {
+            log.warn("[ReconcileCancel] txId={} 예상치 못한 TX 상태입니다. status={}", txId, transaction.status)
+        }
+
+        return transaction
+    }
+
+    /**
+     * Payment 원장에 취소 금액을 강제로 차감합니다.
+     * 카드사에서는 이미 취소 처리가 완료된 상태이므로, 로컬 원장 상태에 관계없이 차감합니다.
+     * applyCancel은 DONE/PARTIAL_CANCEL 상태에서만 동작하므로, 0건이면 수동 처리가 필요합니다.
+     */
+    private fun forciblyApplyCancelToPaymentLedger(command: ReconcileCancelCommand) {
+        val affectedRows = paymentMutationRepository.applyCancel(command.paymentKey, command.amount)
+
+        if (affectedRows == 0) {
+            log.error(
+                "[ReconcileCancel] Payment 원장 차감 실패 — 수동 확인 필요. " +
+                        "txId={}, paymentKey={}, amount={}",
+                command.txId, command.paymentKey, command.amount,
+            )
+            throw BusinessException(PaymentErrorCode.PAYMENT_STATE_MISMATCH)
+        }
+    }
+
+    /**
+     * PaymentTransaction의 needReconciliation 플래그를 해제하고 상태를 SUCCESS로 보정합니다.
+     */
+    private fun markTransactionAsReconciled(transaction: PaymentTransaction) {
+        transaction.markReconciliationDone()
+        paymentTransactionRepository.saveAndFlush(transaction)
+    }
+
+    private fun alreadyResolvedResult(command: ReconcileCancelCommand) = ReconcileCancelResult(
+        txId = command.txId,
+        paymentKey = command.paymentKey,
+        outcome = ReconcileCancelResult.Outcome.ALREADY_RESOLVED,
+        message = "이미 보정이 완료된 건입니다.",
+    )
+}

--- a/src/main/kotlin/com/pgcore/core/application/usecase/batch/ReconcileCancelService.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/batch/ReconcileCancelService.kt
@@ -1,5 +1,6 @@
 package com.pgcore.core.application.usecase.batch
 
+import com.pgcore.core.application.repository.CancelApplyResult
 import com.pgcore.core.application.repository.PaymentMutationRepository
 import com.pgcore.core.application.repository.PaymentTransactionRepository
 import com.pgcore.core.application.usecase.batch.dto.ReconcileCancelCommand
@@ -88,9 +89,9 @@ class ReconcileCancelService(
      * applyCancel은 DONE/PARTIAL_CANCEL 상태에서만 동작하므로, 0건이면 수동 처리가 필요합니다.
      */
     private fun forciblyApplyCancelToPaymentLedger(command: ReconcileCancelCommand) {
-        val affectedRows = paymentMutationRepository.applyCancel(command.paymentKey, command.amount)
+        val applyResult = paymentMutationRepository.applyCancel(command.paymentKey, command.amount)
 
-        if (affectedRows == 0) {
+        if (applyResult.isNoneCancel()) {
             log.error(
                 "[ReconcileCancel] Payment 원장 차감 실패 — 수동 확인 필요. " +
                         "txId={}, paymentKey={}, amount={}",

--- a/src/main/kotlin/com/pgcore/core/application/usecase/batch/ReconcileCancelUseCase.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/batch/ReconcileCancelUseCase.kt
@@ -1,0 +1,14 @@
+package com.pgcore.core.application.usecase.batch
+
+import com.pgcore.core.application.usecase.batch.dto.ReconcileCancelCommand
+import com.pgcore.core.application.usecase.batch.dto.ReconcileCancelResult
+
+/**
+ * 대사(Reconciliation) 보정 유스케이스
+ *
+ * 카드사 취소는 성공했으나 로컬 원장 반영이 실패한 건(needReconciliation=true)에 대해
+ * 로컬 Payment 원장을 강제로 보정합니다.
+ */
+interface ReconcileCancelUseCase {
+    fun execute(command: ReconcileCancelCommand): ReconcileCancelResult
+}

--- a/src/main/kotlin/com/pgcore/core/application/usecase/batch/dto/ReconcileCancelCommand.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/batch/dto/ReconcileCancelCommand.kt
@@ -1,0 +1,16 @@
+package com.pgcore.core.application.usecase.batch.dto
+
+/**
+ * 대사(Reconciliation) 보정 배치 실행 커맨드
+ *
+ * @param txId         보정 대상 PaymentTransaction ID
+ * @param paymentKey   결제 원장 키
+ * @param providerTxId 카드사에서 발급한 취소 거래번호 (대사 대조용)
+ * @param amount       취소 금액 (원 단위)
+ */
+data class ReconcileCancelCommand(
+    val txId: Long,
+    val paymentKey: String,
+    val providerTxId: String,
+    val amount: Long,
+)

--- a/src/main/kotlin/com/pgcore/core/application/usecase/batch/dto/ReconcileCancelResult.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/batch/dto/ReconcileCancelResult.kt
@@ -1,0 +1,20 @@
+package com.pgcore.core.application.usecase.batch.dto
+
+/**
+ * 대사(Reconciliation) 보정 단건 처리 결과
+ */
+data class ReconcileCancelResult(
+    val txId: Long,
+    val paymentKey: String,
+    val outcome: Outcome,
+    val message: String? = null,
+) {
+    enum class Outcome {
+        /** 로컬 원장 보정 완료 */
+        SUCCESS,
+        /** 이미 보정이 완료된 건 (멱등성) */
+        ALREADY_RESOLVED,
+        /** 보정 처리 중 오류 발생 */
+        ERROR,
+    }
+}

--- a/src/main/kotlin/com/pgcore/core/application/usecase/command/CancelStep2Writer.kt
+++ b/src/main/kotlin/com/pgcore/core/application/usecase/command/CancelStep2Writer.kt
@@ -9,8 +9,8 @@ import com.pgcore.core.application.usecase.command.dto.CancelPaymentCommand
 import com.pgcore.core.domain.exception.PaymentErrorCode
 import com.pgcore.core.domain.payment.PaymentTransaction
 import com.pgcore.core.domain.payment.PaymentTxFailureCode
-import com.pgcore.core.domain.payment.vo.Money
 import com.pgcore.core.exception.BusinessException
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -21,6 +21,8 @@ class CancelStep2Writer(
     private val paymentTransactionRepository: PaymentTransactionRepository,
     private val paymentRepository: PaymentRepository,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun finalizeCancel(
         command: CancelPaymentCommand,
@@ -35,9 +37,9 @@ class CancelStep2Writer(
                 val affectedRows = paymentMutationRepository.applyCancel(command.paymentKey, command.amount)
 
                 if (affectedRows == 0) {
-                    handleApplyCancelFailure(command, transaction)
+                    handleApplyCancelFailure(command, transaction, providerTxId)
                 } else {
-                    transaction.markSuccess(null)
+                    transaction.markSuccess(providerTxId)
                 }
             } else {
                 val mappedCode = PaymentTxFailureCode.fromRawCode(failureCode)
@@ -55,38 +57,45 @@ class CancelStep2Writer(
     private fun handleApplyCancelFailure(
         command: CancelPaymentCommand,
         transaction: PaymentTransaction,
+        providerTxId: String?
     ) {
         val payment = paymentRepository.findByPaymentKey(command.paymentKey)
             ?: throw BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND)
 
-        val moneyToCancel = Money(command.amount)
-
-        val isNotCancelable = !payment.canCancelWith(moneyToCancel)
         val isAlreadyProcessed = paymentTransactionRepository.existsSuccessCancelTx(
             payment.paymentId, command.amount, command.idempotencyKey
         )
 
         when {
-            // 취소 불가능 상태 (상태 불일치/잔액 부족 등): 망취소 마킹 후 도메인 예외 발생
-            isNotCancelable -> {
-                transaction.markNeedNetCancel(null)
-                payment.applyCancel(moneyToCancel)
-            }
-
-            // (b) 멱등성: 이미 성공한 동일 취소 건이 존재하면 성공으로 간주
+            // (a) 멱등성: 이미 성공한 동일 취소 건이 존재하면 성공으로 간주
             isAlreadyProcessed -> {
-                transaction.markSuccess(null)
+                transaction.markSuccess(providerTxId)
             }
 
-            // (c) 기타 원인 불명 (DB 장애 등): 안전하게 망취소 대상으로 분류
+            // (b) 실제 불일치: 동일 취소 건이 없는데 UPDATE가 0건이면 카드사-로컬 간 상태 불일치로 판단하여 reconciliation 필요 표시
             else -> {
-                transaction.markNeedNetCancel(null)
+                log.error(
+                    "[CancelReconciliation] 불일치 발생! 카드사 취소 성공 / 로컬 반영 실패. " +
+                            "txId={}, paymentKey={}, amount={}, providerTxId={}",
+                    transaction.id, command.paymentKey, command.amount, providerTxId
+                )
+
+                transaction.markNeedReconciliation(providerTxId)
             }
         }
     }
 
+    /**
+     * 카드사 API 호출 이후 로컬 DB 처리 중 예외가 발생했을 때 호출됩니다.
+     * 새로운 트랜잭션(REQUIRES_NEW)으로 열어 외부 트랜잭션 롤백과 무관하게 상태를 저장합니다.
+     *
+     * - 카드사 취소 성공(SUCCESS) + 로컬 예외: needReconciliation 마킹
+     *   → 카드사는 이미 취소 완료 상태이므로 망취소(Net Cancel)가 아닌 로컬 원장 보정(Reconciliation) 필요
+     * - 카드사 응답 불명(null) 또는 실패: UNKNOWN 마킹
+     *   → 카드사 측 상태가 불확실하므로 재시도 대상으로 분류
+     */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    fun handleExceptionAndMarkUnknown(
+    fun markReconciliationOrUnknownOnException(
         txId: Long,
         cancelStatus: CardProviderResponseStatus?,
         providerTxId: String?
@@ -94,7 +103,12 @@ class CancelStep2Writer(
         val transaction = paymentTransactionRepository.findById(txId) ?: return
 
         if (cancelStatus == CardProviderResponseStatus.SUCCESS) {
-            transaction.markNeedNetCancel(providerTxId)
+            log.error(
+                "[CancelReconciliation] 카드사 취소 성공 후 로컬 예외 발생 — needReconciliation 마킹. " +
+                        "txId={}, providerTxId={}",
+                txId, providerTxId
+            )
+            transaction.markNeedReconciliation(providerTxId)
         } else {
             transaction.markUnknown()
         }

--- a/src/main/kotlin/com/pgcore/core/domain/payment/PaymentTransaction.kt
+++ b/src/main/kotlin/com/pgcore/core/domain/payment/PaymentTransaction.kt
@@ -77,6 +77,10 @@ class PaymentTransaction protected constructor(
     var needNetCancel: Boolean = false
         protected set
 
+    @Column(name = "need_reconciliation", nullable = false)
+    var needReconciliation: Boolean = false
+        protected set
+
     @Column(name = "attempt_count", nullable = false)
     var attemptCount: Int = 0
         protected set
@@ -194,6 +198,29 @@ class PaymentTransaction protected constructor(
         this.updatedAt = LocalDateTime.now()
     }
 
+    /**
+     * 카드사 취소(Cancel)는 성공했으나 로컬 원장(Payment) 상태 반영이 실패한 경우.
+     * 망취소(needNetCancel)와 달리 PG사 측은 이미 정상 처리된 상태이므로,
+     * 대사(Reconciliation) 배치가 로컬 원장만 SUCCESS로 보정해야 함.
+     */
+    fun markNeedReconciliation(providerTxId: String?) {
+        this.status = PaymentTxStatus.UNKNOWN
+        this.providerTxId = providerTxId
+        this.needReconciliation = true
+        this.failureCode = PaymentTxFailureCode.PROVIDER_SUCCESS_LOCAL_FAIL
+        this.failureMessage = "카드사 취소 성공, 로컬 원장 반영 실패 - 대사 보정 필요"
+        this.updatedAt = LocalDateTime.now()
+    }
+
+    /**
+     * 대사(Reconciliation) 배치가 로컬 원장 보정을 완료한 경우.
+     */
+    fun markReconciliationDone() {
+        this.status = PaymentTxStatus.SUCCESS
+        this.needReconciliation = false
+        this.updatedAt = LocalDateTime.now()
+    }
+
     fun bumpAttempt(nextAttemptAt: LocalDateTime? = null) {
         if (!status.isRetryable())
             throw BusinessException(PaymentTransactionErrorCode.INVALID_STATUS_TRANSITION)
@@ -234,7 +261,13 @@ enum class PaymentTxFailureCode(val defaultMessage: String) {
     MERCHANT_NOT_ALLOWED("해당 가맹점에서는 사용이 허용되지 않아 승인에 실패했습니다."),
     DUPLICATE_REQUEST("중복 승인 요청으로 카드사에서 거절했습니다."),
     INTERNAL_ERROR("승인 처리 중 내부 오류가 발생했습니다."),
-    NET_CANCEL_DONE("카드사 망취소가 완료되었습니다.");
+    NET_CANCEL_DONE("카드사 망취소가 완료되었습니다."),
+    /**
+     * 카드사(Provider)에서는 승인/취소에 성공했으나,
+     * 로컬 원장(Payment) 상태 반영(CAS 업데이트 실패, DB 장애 등)이 실패한 경우.
+     * 대사(Reconciliation) 배치를 통해 로컬 원장을 보정해야 함.
+     */
+    PROVIDER_SUCCESS_LOCAL_FAIL("카드사 처리는 성공했으나 내부 원장 반영에 실패했습니다. 대사 보정이 필요합니다.");
 
     fun buildReason(rawCode: String?): String {
         val suffix = rawCode?.let { " (code=$it)" } ?: ""

--- a/src/main/kotlin/com/pgcore/core/infra/adapter/out/card/CardCancelGatewayHttpClient.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/adapter/out/card/CardCancelGatewayHttpClient.kt
@@ -35,6 +35,7 @@ class CardCancelGatewayHttpClient(
     data class MockCancelResponse(
         val providerRequestId: String,
         val status: String,
+        val providerTxId: String? = null,
         val canceledAmount: Long?,
         val remainingAmount: Long?,
         val failureCode: String?,
@@ -70,6 +71,7 @@ class CardCancelGatewayHttpClient(
 
         return CardCancelResult(
             status = cancelStatus,
+            providerTxId = response.providerTxId,
             canceledAmount = response.canceledAmount,
             remainingAmount = response.remainingAmount,
             failureCode = response.failureCode

--- a/src/main/kotlin/com/pgcore/core/infra/batch/ReconcileCancelBatchJob.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/batch/ReconcileCancelBatchJob.kt
@@ -1,0 +1,115 @@
+package com.pgcore.core.infra.batch
+
+import com.pgcore.core.application.repository.PaymentRepository
+import com.pgcore.core.application.usecase.batch.ReconcileCancelUseCase
+import com.pgcore.core.application.usecase.batch.dto.ReconcileCancelCommand
+import com.pgcore.core.application.usecase.batch.dto.ReconcileCancelResult
+import com.pgcore.core.domain.payment.Payment
+import com.pgcore.core.domain.payment.PaymentTransaction
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+/**
+ * 대사(Reconciliation) 보정 배치
+ *
+ * needReconciliation == true 인 건들을 주기적으로 조회하여
+ * ReconcileCancelUseCase를 통해 로컬 Payment 원장을 자동으로 강제 보정합니다.
+ *
+ * 분산 중복 실행 방지: [ReconcileCancelTargetFetcher]가 SELECT FOR UPDATE SKIP LOCKED를 사용하므로
+ * 다중 인스턴스 환경에서도 동일 건의 중복 처리가 발생하지 않습니다.
+ */
+@Component
+class ReconcileCancelBatchJob(
+    private val targetFetcher: ReconcileCancelTargetFetcher,
+    private val paymentRepository: PaymentRepository,
+    private val reconcileCancelUseCase: ReconcileCancelUseCase,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(cron = "0 * * * * *")
+    fun run() {
+        val targets = targetFetcher.fetchReconciliationTargetsWithLock()
+
+        if (targets.isEmpty()) return
+
+        log.info("[ReconcileCancelBatch] 처리 대상 {}건 조회", targets.size)
+
+        val paymentMap = paymentRepository
+            .findAllByPaymentIds(targets.map { it.paymentId }.distinct())
+            .associateBy { it.paymentId }
+
+        val results = targets.map { tx ->
+            processTransaction(tx, paymentMap[tx.paymentId])
+        }
+
+        logBatchSummary(targets.size, results)
+    }
+
+    private fun processTransaction(tx: PaymentTransaction, payment: Payment?): ReconcileCancelResult {
+        val command = buildCommand(tx, payment)
+            ?: return skippedDueToMissingInfoResult(tx)
+
+        return reconcileCancelUseCase.execute(command)
+            .also { logTransactionResult(tx.id, it) }
+    }
+
+    private fun buildCommand(tx: PaymentTransaction, payment: Payment?): ReconcileCancelCommand? {
+        val paymentKey = resolvePaymentKey(tx, payment) ?: return null
+        val providerTxId = resolveProviderTxId(tx) ?: return null
+
+        return ReconcileCancelCommand(
+            txId = tx.id,
+            paymentKey = paymentKey,
+            providerTxId = providerTxId,
+            amount = tx.requestedAmount.amount,
+        )
+    }
+
+    private fun resolvePaymentKey(tx: PaymentTransaction, payment: Payment?): String? {
+        if (payment == null) {
+            log.error(
+                "[ReconcileCancelBatch] txId={} paymentId={}에 해당하는 Payment 원장 없음. 수동 처리 필요.",
+                tx.id, tx.paymentId,
+            )
+        }
+        return payment?.paymentKey
+    }
+
+    private fun resolveProviderTxId(tx: PaymentTransaction): String? {
+        val providerTxId = tx.providerTxId.takeUnless { it.isNullOrBlank() }
+        if (providerTxId == null) {
+            log.error("[ReconcileCancelBatch] txId={} providerTxId 없음. 수동 처리 필요.", tx.id)
+        }
+        return providerTxId
+    }
+
+    private fun logTransactionResult(txId: Long, result: ReconcileCancelResult) {
+        when (result.outcome) {
+            ReconcileCancelResult.Outcome.SUCCESS ->
+                log.info("[ReconcileCancelBatch] txId={} 대사 보정 완료", txId)
+            ReconcileCancelResult.Outcome.ALREADY_RESOLVED ->
+                log.info("[ReconcileCancelBatch] txId={} 이미 보정 완료된 건 (멱등성)", txId)
+            ReconcileCancelResult.Outcome.ERROR ->
+                log.error("[ReconcileCancelBatch] txId={} 보정 처리 실패 (수동 처리 필요): {}", txId, result.message)
+        }
+    }
+
+    private fun logBatchSummary(totalCount: Int, results: List<ReconcileCancelResult>) {
+        val successCount = results.count { it.outcome == ReconcileCancelResult.Outcome.SUCCESS }
+        val alreadyCount = results.count { it.outcome == ReconcileCancelResult.Outcome.ALREADY_RESOLVED }
+        val errorCount   = results.count { it.outcome == ReconcileCancelResult.Outcome.ERROR }
+
+        log.info(
+            "[ReconcileCancelBatch] 완료 — 전체: {}건 | 보정완료: {}건 | 이미처리: {}건 | 오류(수동처리): {}건",
+            totalCount, successCount, alreadyCount, errorCount,
+        )
+    }
+
+    private fun skippedDueToMissingInfoResult(tx: PaymentTransaction) = ReconcileCancelResult(
+        txId = tx.id,
+        paymentKey = "",
+        outcome = ReconcileCancelResult.Outcome.ERROR,
+        message = "필수 정보(paymentKey 또는 providerTxId) 누락으로 처리 불가 — 수동 처리 필요",
+    )
+}

--- a/src/main/kotlin/com/pgcore/core/infra/batch/ReconcileCancelTargetFetcher.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/batch/ReconcileCancelTargetFetcher.kt
@@ -1,0 +1,15 @@
+package com.pgcore.core.infra.batch
+
+import com.pgcore.core.application.repository.PaymentTransactionRepository
+import com.pgcore.core.domain.payment.PaymentTransaction
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class ReconcileCancelTargetFetcher(
+    private val paymentTransactionRepository: PaymentTransactionRepository,
+) {
+    @Transactional
+    fun fetchReconciliationTargetsWithLock(limit: Int = 100): List<PaymentTransaction> =
+        paymentTransactionRepository.findPendingReconciliations(limit)
+}

--- a/src/main/kotlin/com/pgcore/core/infra/repository/PaymentMutationRepositoryImpl.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/repository/PaymentMutationRepositoryImpl.kt
@@ -68,6 +68,32 @@ class PaymentMutationRepositoryImpl(
             .toInt()
             .also { em.clear() }
 
+    override fun reconcileApproveSuccess(paymentKey: String): Int =
+        queryFactory
+            .update(payment)
+            .set(payment.status, PaymentStatus.DONE)
+            .set(payment.updatedAt, LocalDateTime.now())
+            .where(
+                payment.paymentKey.eq(paymentKey),
+                payment.status.`in`(PaymentStatus.IN_PROGRESS, PaymentStatus.UNKNOWN),
+            )
+            .execute()
+            .toInt()
+            .also { em.clear() }
+
+    override fun reconcileApproveFail(paymentKey: String): Int =
+        queryFactory
+            .update(payment)
+            .set(payment.status, PaymentStatus.ABORTED)
+            .set(payment.updatedAt, LocalDateTime.now())
+            .where(
+                payment.paymentKey.eq(paymentKey),
+                payment.status.`in`(PaymentStatus.IN_PROGRESS, PaymentStatus.UNKNOWN),
+            )
+            .execute()
+            .toInt()
+            .also { em.clear() }
+
     override fun applyCancel(paymentKey: String, cancelAmount: Long): CancelApplyResult {
         val now = LocalDateTime.now()
         

--- a/src/main/kotlin/com/pgcore/core/infra/repository/PaymentTransactionRepositoryImpl.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/repository/PaymentTransactionRepositoryImpl.kt
@@ -49,4 +49,9 @@ class PaymentTransactionRepositoryImpl(
             now = now,
             pageable = org.springframework.data.domain.PageRequest.of(0, limit),
         )
+
+    override fun findPendingReconciliations(limit: Int): List<PaymentTransaction> =
+        jpaRepository.findPendingReconciliationsForUpdate(
+            pageable = org.springframework.data.domain.PageRequest.of(0, limit),
+        )
 }

--- a/src/main/kotlin/com/pgcore/core/infra/repository/SpringDataPaymentTransactionJpaRepository.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/repository/SpringDataPaymentTransactionJpaRepository.kt
@@ -33,4 +33,16 @@ interface SpringDataPaymentTransactionJpaRepository : JpaRepository<PaymentTrans
         """
     )
     fun findPendingNetCancelsForUpdate(now: LocalDateTime, pageable: Pageable): List<PaymentTransaction>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(QueryHint(name = "jakarta.persistence.lock.timeout", value = "-2"))
+    @Query(
+        """
+        SELECT t FROM PaymentTransaction t
+        WHERE t.needReconciliation = true
+          AND t.status = com.pgcore.core.domain.payment.PaymentTxStatus.UNKNOWN
+        ORDER BY t.id ASC
+        """
+    )
+    fun findPendingReconciliationsForUpdate(pageable: Pageable): List<PaymentTransaction>
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: ${DB_DDL_AUTO}
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,5 +68,14 @@ outbox:
 mock-card-server:
   url: ${MOCK_CARD_SERVER_URL}
 
+payment:
+  reconciliation:
+    unknown:
+      enabled: ${PAYMENT_RECON_UNKNOWN_ENABLED}
+      interval-ms: ${PAYMENT_RECON_UNKNOWN_INTERVAL_MS}
+      batch-size: ${PAYMENT_RECON_UNKNOWN_BATCH_SIZE}
+      lease-seconds: ${PAYMENT_RECON_UNKNOWN_LEASE_SECONDS}
+      max-retry-attempts: ${PAYMENT_RECON_UNKNOWN_MAX_RETRY_ATTEMPTS}
+
 aws:
   region: ${AWS_REGION}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -24,6 +24,18 @@ webhook:
   endpoint:
     require-https: false
 
+mock-card-server:
+  url: http://localhost:8081
+
+payment:
+  reconciliation:
+    unknown:
+      enabled: false
+      interval-ms: 1000
+      batch-size: 10
+      lease-seconds: 30
+      max-retry-attempts: 6
+
 DB_USER: test
 DB_PASSWORD: test
 WEBHOOK_SECRET_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=


### PR DESCRIPTION
## 💡 PR 개요

PG사(카드사) 취소 요청은 성공했으나, 네트워크 타임아웃이나 내부 시스템 장애 등으로 인해 로컬 결제 원장(`Payment`)에 취소 상태가 정상적으로 반영되지 않아 발생한 데이터 불일치 건을 자동으로 복구하는 '취소 대사 보정(Reconcile Cancel) 배치 파이프라인'을 구현했습니다. 이를 통해 파트너사와의 정산 분쟁을 예방하고 데이터 정합성을 보장합니다.

## 🛠️ 주요 변경 사항 및 작업 내용

### **1. 대사 보정 배치 스케줄러 구현 (`ReconcileCancelBatchJob`)**

- 1분 주기(`0 * * * * *`)로 동작하며 `needReconciliation == true` 상태인 보정 대상 트랜잭션을 자동으로 감지하고 처리하는 크론(Cron) 배치를 구성했습니다.
- 성공, 이미 처리됨(멱등성), 오류 발생 등 배치 실행 결과를 집계하여 한눈에 파악할 수 있도록 로깅 처리를 세분화했습니다.

### **2. 다중 인스턴스 환경 동시성 제어 (`ReconcileCancelTargetFetcher`)**

- 다중 서버 환경에서 동일한 보정 대상을 중복으로 가져가는 문제를 방지하기 위해 DB 락(`fetchReconciliationTargetsWithLock`)을 적용하여 최대 100건씩 안전하게 조회하도록 구현했습니다.

### **3. 핵심 보정 비즈니스 로직 및 트랜잭션 격리 (`ReconcileCancelService`)**

- 대량 배치 처리 중 단일 건의 예외가 전체 배치의 롤백으로 이어지지 않도록 `@Transactional(propagation = Propagation.REQUIRES_NEW)`를 적용하여 각각의 보정 건을 독립된 트랜잭션으로 격리했습니다.
- **강제 원장 차감 로직 (`forciblyApplyCancelToPaymentLedger`):** 카드사에서는 이미 취소 처리가 완료된 상태이므로, 로컬 원장 상태와 무관하게 `PaymentMutationRepository`를 통해 무조건적으로 취소 금액을 차감(`applyCancel`)하여 정합성을 강제합니다.
- 보정이 완료되면 `PaymentTransaction`의 `needReconciliation` 플래그를 해제하고 상태를 `SUCCESS`로 업데이트하여 마무리합니다.

### **4. 멱등성 보장 및 예외 방어**

- 보정 로직 진입 전 1차적으로 `!transaction.needReconciliation` 조건을 검사하여, 이미 보정이 완료된 건에 대해 중복 처리를 방지하고 `ALREADY_RESOLVED` 결과를 반환하도록 멱등성을 보장했습니다.
- 필수 정보(`paymentKey`, `providerTxId`)가 누락되었거나 원장 강제 차감(`affectedRows == 0`)에 실패하는 등 자동 보정이 불가능한 케이스는 즉각 예외(`ERROR`)로 분류하고, 수동 처리를 위한 에러 로그를 명확히 남기도록 구현했습니다.