### PR TITLE
fix(payment): 결제 취소 검증 로직 추가

### DIFF
--- a/src/main/kotlin/com/pgcore/core/application/service/PaymentService.kt
+++ b/src/main/kotlin/com/pgcore/core/application/service/PaymentService.kt
@@ -224,6 +224,9 @@ class PaymentService(
     }
 
     private fun validateCancelRequest(payment: Payment, command: CancelPaymentCommand) {
+        if (command.amount <= 0) {
+            throw BusinessException(PaymentErrorCode.INVALID_CANCEL_AMOUNT)
+        }
         payment.status.requireCancelable()
         if (payment.balanceAmount < Money(command.amount)) {
             throw BusinessException(PaymentErrorCode.EXCEED_CANCEL_AMOUNT)

--- a/src/main/kotlin/com/pgcore/core/infra/repository/PaymentMutationRepositoryImpl.kt
+++ b/src/main/kotlin/com/pgcore/core/infra/repository/PaymentMutationRepositoryImpl.kt
@@ -106,7 +106,7 @@ class PaymentMutationRepositoryImpl(
             .fetchOne()
             ?: return CancelApplyResult.PAYMENT_NOT_FOUND
 
-        if (lockedPayment.status == PaymentStatus.CANCEL || lockedPayment.status == PaymentStatus.PARTIAL_CANCEL) {
+        if (lockedPayment.status == PaymentStatus.CANCEL) {
             return CancelApplyResult.ALREADY_CANCELED
         }
 


### PR DESCRIPTION
## 💡 PR 개요
부하 테스트 과정에서 발견된 취소 금액 0원 검증 누락 및 부분 취소 연속 요청 시 발생하는 로직 오류를 수정하여 전체적인 취소 플로우의 안정성을 강화했습니다.



## 🛠️ 주요 변경 사항 및 작업 내용

 1. 취소 금액 유효성 검증 강화 (PaymentService)
   - 0원 취소 차단: PaymentService의 validateCancelRequest 단계에서 취소 금액이 0원 이하인 경우를 사전에 차단하도록 검증 로직을 추가했습니다.
   - 이를 통해 불필요한 외부 API 호출을 방지하고, 클라이언트에게 즉각적인 INVALID_CANCEL_AMOUNT (400 Bad Request) 에러를 반환하여 규격에 맞는 응답을 보장합니다.


  2. 부분 취소 연속 요청(Multi-Partial Cancel) 버그 수정 (PaymentMutationRepository)
   - 상태 기반 차단 로직 개선: 기존 PaymentMutationRepositoryImpl에서 결제 상태가 PARTIAL_CANCEL인 경우 무조건 중복 요청으로 간주하여 추가 취소를 막던 버그를 수정했습니다.
   - 이제 이미 전액 취소된 상태(CANCEL)인 경우에만 멱등성 예외(ALREADY_CANCELED)를 반환하며, PARTIAL_CANCEL 상태에서는 남은 잔액 범위 내에서 연속적인 부분 취소가 가능하도록 로직을 정상화했습니다.

